### PR TITLE
fix(adapters): #15 Tauriアダプターのエラー伝播修正

### DIFF
--- a/src/features/folder-navigation/containers/LocalFolderContainer.ts
+++ b/src/features/folder-navigation/containers/LocalFolderContainer.ts
@@ -11,38 +11,32 @@ export class LocalFolderContainer implements ImageContainer {
   ) {}
 
   async listImages(): Promise<ImageSource[]> {
-    try {
-      const files = await this.fs.listImagesInFolder(this.folderPath);
+    const files = await this.fs.listImagesInFolder(this.folderPath);
 
-      // Tauriのコマンドの戻り値が文字列の配列であることを確認する
-      if (!isStringArray(files)) {
-        throw new Error(
-          `Invalid response from FileSystemService. Expected an array of strings. Received: ${files} of type ${typeof files}`,
-        );
-      }
-
-      const imageSources = await Promise.all(
-        files.map(async (imgPath) => {
-          // ファイルパスからファイル名を取得する
-          const fileBasename = await this.fs.getBaseName(imgPath);
-          return {
-            id: imgPath,
-            name: fileBasename,
-            assetUrl: this.fs.convertFileSrc(imgPath),
-          };
-        }),
-      ).catch((error) => {
-        console.error('Error converting file paths to asset URLs:', error);
-        throw new Error(`Failed to convert file paths to asset URLs: ${error}`);
-      });
-
-      // 画像を名前でソートする
-      imageSources.sort(naturalSort);
-
-      return imageSources;
-    } catch (error) {
-      console.error('Error listing images in folder:', error);
-      return [];
+    // Tauriのコマンドの戻り値が文字列の配列であることを確認する
+    if (!isStringArray(files)) {
+      throw new Error(
+        `Invalid response from FileSystemService. Expected an array of strings. Received: ${files} of type ${typeof files}`,
+      );
     }
+
+    const imageSources = await Promise.all(
+      files.map(async (imgPath) => {
+        // ファイルパスからファイル名を取得する
+        const fileBasename = await this.fs.getBaseName(imgPath);
+        return {
+          id: imgPath,
+          name: fileBasename,
+          assetUrl: this.fs.convertFileSrc(imgPath),
+        };
+      }),
+    ).catch((error) => {
+      throw new Error(`Failed to convert file paths to asset URLs: ${error}`);
+    });
+
+    // 画像を名前でソートする
+    imageSources.sort(naturalSort);
+
+    return imageSources;
   }
 }

--- a/src/features/folder-navigation/hooks/__tests__/useSiblingFolders.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useSiblingFolders.test.tsx
@@ -110,9 +110,6 @@ describe('useFolderNavigator', () => {
   });
 
   it('getSiblingFolders がエラーをスローした場合、entries は空配列になること', async () => {
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
     mockFileSystemService.getSiblingFolders = vi
       .fn()
       .mockRejectedValue(new Error('Failed to get sibling folders'));
@@ -127,8 +124,25 @@ describe('useFolderNavigator', () => {
     expect(mockFileSystemService.getSiblingFolders).toHaveBeenCalledWith(
       TEST_CURRENT_PATH,
     );
-    expect(consoleErrorSpy).toHaveBeenCalled();
-    consoleErrorSpy.mockRestore();
+  });
+
+  it('getSiblingFolders がエラーの場合、error ステートに格納される', async () => {
+    const errorMessage = 'Failed to get sibling folders';
+    mockFileSystemService.getSiblingFolders = vi
+      .fn()
+      .mockRejectedValue(new Error(errorMessage));
+
+    const { result } = renderHook(() => useSiblingFolders(TEST_CURRENT_PATH), {
+      wrapper: ServicesWrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([]);
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toContain(
+        'Failed to get sibling folders',
+      );
+    });
   });
 
   it('フックがアンマウントされた場合、進行中の処理がキャンセルされること (setEntries が呼ばれないこと)', async () => {

--- a/src/features/folder-navigation/hooks/useSiblingFolders.ts
+++ b/src/features/folder-navigation/hooks/useSiblingFolders.ts
@@ -28,6 +28,8 @@ export async function createFolderEntry(
 export function useSiblingFolders(currentFolderPath: string) {
   // 同階層のフォルダ情報（パス・名前）のリストを保持するstate
   const [entries, setEntries] = useState<FolderEntry[]>([]);
+  // エラー状態を保持するstate
+  const [error, setError] = useState<Error | null>(null);
 
   // ファイルシステム関連のサービスを取得
   const fs = useServices();
@@ -42,13 +44,20 @@ export function useSiblingFolders(currentFolderPath: string) {
         return;
       }
 
-      // 各フォルダパスからフォルダ名を取得し、FolderEntry配列を生成
-      const entries = await getSiblingFolderEntries(currentFolderPath, fs);
+      try {
+        // エラーをリセット
+        setError(null);
 
-      // 非緊急な状態更新
-      startTransition(() => {
-        setEntries(entries);
-      });
+        // 各フォルダパスからフォルダ名を取得し、FolderEntry配列を生成
+        const entries = await getSiblingFolderEntries(currentFolderPath, fs);
+
+        // 非緊急な状態更新
+        startTransition(() => {
+          setEntries(entries);
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
     }
 
     // 副作用としてデータ取得処理を実行
@@ -60,5 +69,5 @@ export function useSiblingFolders(currentFolderPath: string) {
     };
   }, [currentFolderPath, fs]);
 
-  return { entries };
+  return { entries, error };
 }

--- a/src/features/folder-navigation/hooks/useSiblingFolders.ts
+++ b/src/features/folder-navigation/hooks/useSiblingFolders.ts
@@ -39,10 +39,7 @@ export function useSiblingFolders(currentFolderPath: string) {
 
     // 指定フォルダと同階層のフォルダ一覧を取得し、各フォルダ名を取得してstateにセットする
     async function load() {
-      if (!mounted) {
-        setEntries([]);
-        return;
-      }
+      if (!mounted) return;
 
       try {
         // エラーをリセット
@@ -51,11 +48,14 @@ export function useSiblingFolders(currentFolderPath: string) {
         // 各フォルダパスからフォルダ名を取得し、FolderEntry配列を生成
         const entries = await getSiblingFolderEntries(currentFolderPath, fs);
 
+        if (!mounted) return;
+
         // 非緊急な状態更新
         startTransition(() => {
           setEntries(entries);
         });
       } catch (err) {
+        if (!mounted) return;
         setError(err instanceof Error ? err : new Error(String(err)));
       }
     }

--- a/src/features/folder-navigation/services/__tests__/getSiblingFolders.test.ts
+++ b/src/features/folder-navigation/services/__tests__/getSiblingFolders.test.ts
@@ -143,38 +143,23 @@ describe('getSiblingFolderEntries', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  it('should return empty array when getSiblingFolders fails', async () => {
+  it('should propagate error when getSiblingFolders fails', async () => {
     const currentPath = '/path/to/current';
-
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
 
     mockFileSystemService.getSiblingFolders = vi
       .fn()
-      .mockRejectedValue(new Error('Failed to get siblings'));
+      .mockRejectedValue(
+        new Error('Failed to get sibling folders for "/path/to/current"'),
+      );
 
-    const result = await getSiblingFolderEntries(
-      currentPath,
-      mockFileSystemService,
-    );
-
-    expect(result).toEqual([]);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error fetching folder entries:',
-      expect.any(Error),
-    );
-
-    consoleErrorSpy.mockRestore();
+    await expect(
+      getSiblingFolderEntries(currentPath, mockFileSystemService),
+    ).rejects.toThrow('Failed to get sibling folders');
   });
 
-  it('should return empty array when sibling folder name resolution fails', async () => {
+  it('should propagate error when sibling folder name resolution fails', async () => {
     const currentPath = '/path/to/current';
     const siblingPaths = ['/path/to/apple', '/path/to/invalid'];
-
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
 
     mockFileSystemService.getSiblingFolders = vi
       .fn()
@@ -188,19 +173,10 @@ describe('getSiblingFolderEntries', () => {
         return '';
       });
 
-    // This should return empty array because Promise.all will reject and be caught
-    const result = await getSiblingFolderEntries(
-      currentPath,
-      mockFileSystemService,
-    );
-
-    expect(result).toEqual([]);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error fetching folder entries:',
-      expect.any(Error),
-    );
-
-    consoleErrorSpy.mockRestore();
+    // Promise.all がrejectし、エラーが伝播される
+    await expect(
+      getSiblingFolderEntries(currentPath, mockFileSystemService),
+    ).rejects.toThrow();
   });
 
   it('should handle numeric folder names correctly with natural sort', async () => {

--- a/src/features/folder-navigation/services/getSiblingFolders.ts
+++ b/src/features/folder-navigation/services/getSiblingFolders.ts
@@ -15,7 +15,7 @@ import type { FileSystemService } from './FileSystemService';
  * @returns FolderEntry[] - 同階層のフォルダ情報（パス・名前）の配列（現在のフォルダを含む、ソート済み）
  *
  * - currentFolderPathが空の場合は空配列を返す
- * - 取得や変換でエラーが発生した場合も空配列を返す
+ * - 取得や変換でエラーが発生した場合は呼び出し元に伝播させる
  * - 現在のフォルダの作成に失敗した場合でも、兄弟フォルダは返す
  */
 export async function getSiblingFolderEntries(

--- a/src/features/folder-navigation/services/getSiblingFolders.ts
+++ b/src/features/folder-navigation/services/getSiblingFolders.ts
@@ -28,28 +28,22 @@ export async function getSiblingFolderEntries(
     return [];
   }
 
+  // エラーは呼び出し元に伝播させる（外側のtry-catchを削除）
+  const paths = await fs.getSiblingFolders(currentFolderPath);
+
+  // 各フォルダパスからベース名を取得し、FolderEntry配列を生成
+  const entries: FolderEntry[] = await Promise.all(
+    paths.map(async (dirPath) => createFolderEntry(dirPath, fs)),
+  );
+
+  // 現在のフォルダも追加（エラーが発生しても兄弟フォルダは返す）
   try {
-    // 同階層のフォルダパス一覧を取得
-    const paths = await fs.getSiblingFolders(currentFolderPath);
-
-    // 各フォルダパスからベース名を取得し、FolderEntry配列を生成
-    const entries: FolderEntry[] = await Promise.all(
-      paths.map(async (dirPath) => createFolderEntry(dirPath, fs)),
-    );
-
-    // 現在のフォルダも追加（エラーが発生しても兄弟フォルダは返す）
-    try {
-      const currentEntry = await createFolderEntry(currentFolderPath, fs);
-      entries.push(currentEntry);
-    } catch (currentFolderError) {
-      console.error('Error creating current folder entry:', currentFolderError);
-    }
-
-    // ソート関数を適用して返す
-    return entries.sort(sortFn);
-  } catch (error) {
-    // 取得や変換でエラーが発生した場合はエラーを出力し、空配列を返す
-    console.error('Error fetching folder entries:', error);
-    return [];
+    const currentEntry = await createFolderEntry(currentFolderPath, fs);
+    entries.push(currentEntry);
+  } catch (currentFolderError) {
+    console.error('Error creating current folder entry:', currentFolderError);
   }
+
+  // ソート関数を適用して返す
+  return entries.sort(sortFn);
 }

--- a/src/shared/adapters/__tests__/tauriAdapters.test.ts
+++ b/src/shared/adapters/__tests__/tauriAdapters.test.ts
@@ -140,8 +140,6 @@ describe('tauriAdapters - Core Functionality', () => {
 describe('tauriAdapters - Error Handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // console.errorをモックしてテスト出力を抑制
-    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -152,17 +150,16 @@ describe('tauriAdapters - Error Handling', () => {
   describe('Backend error scenarios', () => {
     beforeEach(() => {
       vi.clearAllMocks();
-      vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
-    it('should handle invoke errors for listImagesInFolder', async () => {
+    it('should propagate invoke errors for listImagesInFolder', async () => {
       const folderPath = '/invalid/path';
       const backendError = new Error('Backend error: Folder not found');
       mockInvoke.mockRejectedValue(backendError);
 
-      const result =
-        await tauriFileSystemService.listImagesInFolder(folderPath);
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.listImagesInFolder(folderPath),
+      ).rejects.toThrow(`Failed to list images in folder "${folderPath}"`);
       expect(mockInvoke).toHaveBeenCalledWith('list_images_in_folder', {
         folderPath,
       });
@@ -173,9 +170,9 @@ describe('tauriAdapters - Error Handling', () => {
       const permissionError = new Error('Permission denied');
       mockInvoke.mockRejectedValue(permissionError);
 
-      const result = await tauriFileSystemService.getSiblingFolders(folderPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(folderPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
 
     it('should handle timeout errors gracefully', async () => {
@@ -183,9 +180,9 @@ describe('tauriAdapters - Error Handling', () => {
       const timeoutError = new Error('Request timeout');
       mockInvoke.mockRejectedValue(timeoutError);
 
-      const result = await tauriFileSystemService.getSiblingFolders(folderPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(folderPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
   });
 
@@ -195,9 +192,9 @@ describe('tauriAdapters - Error Handling', () => {
       const backendError = new Error('Invalid path: empty string');
       mockInvoke.mockRejectedValue(backendError);
 
-      const result = await tauriFileSystemService.listImagesInFolder(emptyPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.listImagesInFolder(emptyPath),
+      ).rejects.toThrow('Failed to list images in folder');
     });
 
     it('should handle null/undefined paths gracefully for getSiblingFolders', async () => {
@@ -205,9 +202,9 @@ describe('tauriAdapters - Error Handling', () => {
       const backendError = new Error('Invalid path: null');
       mockInvoke.mockRejectedValue(backendError);
 
-      const result = await tauriFileSystemService.getSiblingFolders(nullPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(nullPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
 
     it('should handle malformed paths for getSiblingFolders', async () => {
@@ -215,10 +212,9 @@ describe('tauriAdapters - Error Handling', () => {
       const backendError = new Error('Malformed path');
       mockInvoke.mockRejectedValue(backendError);
 
-      const result =
-        await tauriFileSystemService.getSiblingFolders(malformedPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(malformedPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
   });
 
@@ -229,9 +225,9 @@ describe('tauriAdapters - Error Handling', () => {
       mockInvoke.mockResolvedValue(invalidResponse);
       mockIsStringArray.mockReturnValue(false);
 
-      const result = await tauriFileSystemService.getSiblingFolders(folderPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(folderPath),
+      ).rejects.toThrow('Failed to get sibling folders');
       expect(mockIsStringArray).toHaveBeenCalledWith(invalidResponse);
     });
 
@@ -241,9 +237,9 @@ describe('tauriAdapters - Error Handling', () => {
       mockInvoke.mockResolvedValue(nullResponse);
       mockIsStringArray.mockReturnValue(false);
 
-      const result = await tauriFileSystemService.getSiblingFolders(folderPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(folderPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
 
     it('should handle array with non-string elements from getSiblingFolders', async () => {
@@ -252,9 +248,9 @@ describe('tauriAdapters - Error Handling', () => {
       mockInvoke.mockResolvedValue(mixedResponse);
       mockIsStringArray.mockReturnValue(false);
 
-      const result = await tauriFileSystemService.getSiblingFolders(folderPath);
-
-      expect(result).toEqual([]);
+      await expect(
+        tauriFileSystemService.getSiblingFolders(folderPath),
+      ).rejects.toThrow('Failed to get sibling folders');
     });
   });
 

--- a/src/shared/adapters/__tests__/tauriAdapters.test.ts
+++ b/src/shared/adapters/__tests__/tauriAdapters.test.ts
@@ -96,6 +96,7 @@ describe('tauriAdapters - Core Functionality', () => {
         '/Users/test/images/photo3.gif',
       ];
       mockInvoke.mockResolvedValue(expectedImages);
+      mockIsStringArray.mockReturnValue(true);
 
       const result =
         await tauriFileSystemService.listImagesInFolder(folderPath);
@@ -109,6 +110,7 @@ describe('tauriAdapters - Core Functionality', () => {
     it('should return empty array when folder has no images', async () => {
       const folderPath = '/Users/test/empty';
       mockInvoke.mockResolvedValue([]);
+      mockIsStringArray.mockReturnValue(true);
 
       const result =
         await tauriFileSystemService.listImagesInFolder(folderPath);
@@ -125,6 +127,7 @@ describe('tauriAdapters - Core Functionality', () => {
         '/Users/test/フォルダ with spaces & symbols!/image.jpg',
       ];
       mockInvoke.mockResolvedValue(expectedImages);
+      mockIsStringArray.mockReturnValue(true);
 
       const result =
         await tauriFileSystemService.listImagesInFolder(folderPath);
@@ -251,6 +254,17 @@ describe('tauriAdapters - Error Handling', () => {
       await expect(
         tauriFileSystemService.getSiblingFolders(folderPath),
       ).rejects.toThrow('Failed to get sibling folders');
+    });
+
+    it('should propagate invalid response from listImagesInFolder', async () => {
+      const folderPath = '/valid/path';
+      mockInvoke.mockResolvedValue(null);
+      mockIsStringArray.mockReturnValue(false);
+
+      await expect(
+        tauriFileSystemService.listImagesInFolder(folderPath),
+      ).rejects.toThrow(`Failed to list images in folder "${folderPath}"`);
+      expect(mockIsStringArray).toHaveBeenCalledWith(null);
     });
   });
 

--- a/src/shared/adapters/tauriAdapters.ts
+++ b/src/shared/adapters/tauriAdapters.ts
@@ -58,11 +58,15 @@ export const tauriFileSystemService: FileSystemService = {
       const images = await invoke<string[]>('list_images_in_folder', {
         folderPath,
       });
-
+      if (!isStringArray(images)) {
+        throw new Error(
+          `Invalid response from listImagesInFolder: expected string array, got ${typeof images}`,
+        );
+      }
       return images;
     } catch (error) {
       throw new Error(
-        `Failed to list images in folder "${folderPath}": ${error}`,
+        `Failed to list images in folder "${folderPath}": ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   },
@@ -80,7 +84,7 @@ export const tauriFileSystemService: FileSystemService = {
       return folders;
     } catch (error) {
       throw new Error(
-        `Failed to get sibling folders for "${folderPath}": ${error}`,
+        `Failed to get sibling folders for "${folderPath}": ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   },

--- a/src/shared/adapters/tauriAdapters.ts
+++ b/src/shared/adapters/tauriAdapters.ts
@@ -61,8 +61,9 @@ export const tauriFileSystemService: FileSystemService = {
 
       return images;
     } catch (error) {
-      console.error(`Error listing images in folder ${folderPath}`, error);
-      return [];
+      throw new Error(
+        `Failed to list images in folder "${folderPath}": ${error}`,
+      );
     }
   },
 
@@ -72,13 +73,15 @@ export const tauriFileSystemService: FileSystemService = {
         folderPath,
       });
       if (!isStringArray(folders)) {
-        console.error('Invalid response from getSiblingFolders:', folders);
-        return [];
+        throw new Error(
+          `Invalid response from getSiblingFolders: expected string array, got ${typeof folders}`,
+        );
       }
       return folders;
     } catch (error) {
-      console.error('Error getting sibling folders:', error);
-      return [];
+      throw new Error(
+        `Failed to get sibling folders for "${folderPath}": ${error}`,
+      );
     }
   },
 

--- a/src/shared/hooks/data/__tests__/useImages.test.tsx
+++ b/src/shared/hooks/data/__tests__/useImages.test.tsx
@@ -64,8 +64,7 @@ describe('useImages', () => {
     });
   });
 
-  it('存在しないフォルダを指定した場合、空の配列を返す', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('存在しないフォルダを指定した場合、エラーが返される', async () => {
     mockFileSystemService.listImagesInFolder = vi.fn().mockReturnValue(null);
 
     const { result } = renderHook(() => useImages('invalid/folder'), {
@@ -73,14 +72,13 @@ describe('useImages', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.images).toEqual([]);
-      expect(result.current.error).toBeUndefined();
+      expect(result.current.images).toBeUndefined();
+      expect(result.current.error).toBeDefined();
       expect(result.current.isLoading).toBe(false);
     });
   });
 
-  it('ファイルアクセスで例外が発生した場合、空の配列を返す', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('ファイルアクセスで例外が発生した場合、エラーが返される', async () => {
     mockFileSystemService.listImagesInFolder = vi
       .fn()
       .mockRejectedValue(new Error('File access error'));
@@ -89,8 +87,8 @@ describe('useImages', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.images).toEqual([]);
-      expect(result.current.error).toBeUndefined();
+      expect(result.current.images).toBeUndefined();
+      expect(result.current.error).toBeDefined();
       expect(result.current.isLoading).toBe(false);
     });
   });


### PR DESCRIPTION
## 概要

Tauri アダプターの `listImagesInFolder` / `getSiblingFolders` がエラーを握り潰して空配列を返していた問題を修正。Rust バックエンドのエラーが UI まで正しく伝播するようにします。

## 変更内容

- `tauriAdapters.ts`: `listImagesInFolder` / `getSiblingFolders` のエラー時を `return []` から `throw new Error(...)` に変更
- `tauriAdapters.ts`: `listImagesInFolder` に `isStringArray` チェックを追加（`getSiblingFolders` と対称化）
- `tauriAdapters.ts`: エラーメッセージ生成を `error instanceof Error ? error.message : String(error)` パターンに統一
- `LocalFolderContainer.ts`: 外側 try-catch を削除し、エラーを SWR まで伝播
- `getSiblingFolders.ts`: 外側 try-catch を削除（現在フォルダ失敗は引き続き許容）、JSDoc を修正
- `useSiblingFolders.ts`: `error` ステートを追加、アンマウント後 setState 競合対策
- テスト 4 ファイル: 新しいエラー伝播動作に更新・テスト追加

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（326 件）

## 関連 Issue

closes #15
