### PR TITLE
fix(sidebar): #14 フォルダ20件超でサイドバーがスクロールできないバグを修正

### DIFF
--- a/src/__tests__/SidebarScroll.test.tsx
+++ b/src/__tests__/SidebarScroll.test.tsx
@@ -36,38 +36,3 @@ describe('SidebarScroll - US2: Sidebar container has correct scroll classes', ()
     expect(sidebarAside.classList.contains('min-h-0')).toBe(true);
   });
 });
-
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { Sidebar } from '@/features/folder-navigation';
-import { resetAllMocks, setupTauriMocks } from '@/test/mocks';
-
-const mockFolders = Array.from({ length: 21 }, (_, i) => ({
-  name: `test-folder-${String(i + 1).padStart(2, '0')}`,
-  path: `/test/folder${i + 1}`,
-}));
-
-describe('SidebarScroll - US2: Sidebar container has correct scroll classes', () => {
-  beforeEach(() => {
-    resetAllMocks();
-    setupTauriMocks();
-  });
-
-  const renderSidebar = () => {
-    return render(<Sidebar folders={mockFolders} onFolderSelect={() => {}} />);
-  };
-
-  it('T009: sidebar aside element should have overflow-y-auto class', () => {
-    renderSidebar();
-    const sidebarAside = screen.getByRole('complementary');
-    expect(sidebarAside).toBeInTheDocument();
-    expect(sidebarAside.classList.contains('overflow-y-auto')).toBe(true);
-  });
-
-  it('T009b: sidebar aside element should have min-h-0 class for correct flex scroll', () => {
-    renderSidebar();
-    const sidebarAside = screen.getByRole('complementary');
-    expect(sidebarAside).toBeInTheDocument();
-    expect(sidebarAside.classList.contains('min-h-0')).toBe(true);
-  });
-});

--- a/src/__tests__/SidebarScroll.test.tsx
+++ b/src/__tests__/SidebarScroll.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Sidebar } from '@/features/folder-navigation';
+import { resetAllMocks, setupTauriMocks } from '@/test/mocks';
+
+const mockFolders = Array.from({ length: 21 }, (_, i) => ({
+  name: `test-folder-${String(i + 1).padStart(2, '0')}`,
+  path: `/test/folder${i + 1}`,
+}));
+
+describe('SidebarScroll - US2: Sidebar container has correct scroll classes', () => {
+  beforeEach(() => {
+    resetAllMocks();
+    setupTauriMocks();
+  });
+
+  const renderSidebar = () => {
+    return render(<Sidebar folders={mockFolders} onFolderSelect={() => {}} />);
+  };
+
+  it('T009: sidebar aside element should have overflow-y-auto class', () => {
+    renderSidebar();
+    const sidebarAside = screen.getByRole('complementary');
+    expect(sidebarAside).toBeInTheDocument();
+    expect(sidebarAside.classList.contains('overflow-y-auto')).toBe(true);
+  });
+
+  it('T009b: sidebar aside element should have min-h-0 class for correct flex scroll', () => {
+    renderSidebar();
+    const sidebarAside = screen.getByRole('complementary');
+    expect(sidebarAside).toBeInTheDocument();
+    expect(sidebarAside.classList.contains('min-h-0')).toBe(true);
+  });
+});

--- a/src/__tests__/SidebarScroll.test.tsx
+++ b/src/__tests__/SidebarScroll.test.tsx
@@ -3,32 +3,36 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { Sidebar } from '@/features/folder-navigation';
 import { resetAllMocks, setupTauriMocks } from '@/test/mocks';
 
-const mockFolders = Array.from({ length: 21 }, (_, i) => ({
+// スクロールが必要な状況を再現するため、表示しきれない件数（20件超）を使用
+const FOLDERS_NEEDING_SCROLL = 21;
+const mockFolders = Array.from({ length: FOLDERS_NEEDING_SCROLL }, (_, i) => ({
   name: `test-folder-${String(i + 1).padStart(2, '0')}`,
   path: `/test/folder${i + 1}`,
 }));
 
+/**
+ * SidebarScroll - スクロール動作のリグレッション検知テスト
+ *
+ * ⚠ NOTE: このテストは実装詳細（CSSクラスの存在）を検証するリグレッション検知テストである。
+ *   jsdom はレイアウトエンジンを持たないため、実際のスクロール動作（scrollHeight > clientHeight）
+ *   を検証することはできない。実際のスクロール動作の確認は Storybook または E2E テストで行うこと。
+ *   実装方式を変更する場合（例: Tailwind クラス → inline style）はこのテストも合わせて更新すること。
+ */
 describe('SidebarScroll - US2: Sidebar container has correct scroll classes', () => {
   beforeEach(() => {
     resetAllMocks();
+    // useThumbnailPrefetch が内部で Tauri API を呼ぶため、モックが必要
     setupTauriMocks();
   });
 
-  const renderSidebar = () => {
-    return render(<Sidebar folders={mockFolders} onFolderSelect={() => {}} />);
-  };
-
-  it('T009: sidebar aside element should have overflow-y-auto class', () => {
-    renderSidebar();
+  it('T009/T009b: フォルダが20件超のとき、スクロールを可能にするスタイル条件が満たされている（リグレッション検知）', () => {
+    render(<Sidebar folders={mockFolders} onFolderSelect={() => {}} />);
     const sidebarAside = screen.getByRole('complementary');
+
     expect(sidebarAside).toBeInTheDocument();
+    // overflow-y-auto: スクロール許可
     expect(sidebarAside.classList.contains('overflow-y-auto')).toBe(true);
-  });
-
-  it('T009b: sidebar aside element should have min-h-0 class for correct flex scroll', () => {
-    renderSidebar();
-    const sidebarAside = screen.getByRole('complementary');
-    expect(sidebarAside).toBeInTheDocument();
+    // min-h-0: Flexbox 子要素のデフォルト min-height: auto を上書きし、overflow が機能するようにする
     expect(sidebarAside.classList.contains('min-h-0')).toBe(true);
   });
 });

--- a/src/__tests__/SidebarScroll.test.tsx
+++ b/src/__tests__/SidebarScroll.test.tsx
@@ -18,21 +18,22 @@ const mockFolders = Array.from({ length: FOLDERS_NEEDING_SCROLL }, (_, i) => ({
  *   を検証することはできない。実際のスクロール動作の確認は Storybook または E2E テストで行うこと。
  *   実装方式を変更する場合（例: Tailwind クラス → inline style）はこのテストも合わせて更新すること。
  */
-describe('SidebarScroll - US2: Sidebar container has correct scroll classes', () => {
+describe('SidebarScroll - スクロール可能な状態が維持されること（リグレッション検知）', () => {
   beforeEach(() => {
     resetAllMocks();
     // useThumbnailPrefetch が内部で Tauri API を呼ぶため、モックが必要
     setupTauriMocks();
   });
 
-  it('T009/T009b: フォルダが20件超のとき、スクロールを可能にするスタイル条件が満たされている（リグレッション検知）', () => {
+  it('フォルダが20件超のとき、スクロールを可能にするスタイル条件が満たされている', () => {
+    // Test ID: T009/T009b
     render(<Sidebar folders={mockFolders} onFolderSelect={() => {}} />);
     const sidebarAside = screen.getByRole('complementary');
 
     expect(sidebarAside).toBeInTheDocument();
     // overflow-y-auto: スクロール許可
-    expect(sidebarAside.classList.contains('overflow-y-auto')).toBe(true);
+    expect(sidebarAside).toHaveClass('overflow-y-auto');
     // min-h-0: Flexbox 子要素のデフォルト min-height: auto を上書きし、overflow が機能するようにする
-    expect(sidebarAside.classList.contains('min-h-0')).toBe(true);
+    expect(sidebarAside).toHaveClass('min-h-0');
   });
 });

--- a/src/features/folder-navigation/components/Sidebar/Sidebar.tsx
+++ b/src/features/folder-navigation/components/Sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ export function Sidebar({
 
   return (
     <aside
-      className={`overflow-y-auto border-sidebar-border bg-sidebar text-sidebar-foreground ${className}`}
+      className={`min-h-0 overflow-y-auto border-sidebar-border bg-sidebar text-sidebar-foreground ${className}`}
       style={{ width, ...style }}
     >
       <div className="p-2">


### PR DESCRIPTION
## 概要

Flexbox 子要素のデフォルト `min-height: auto` により `overflow-y-auto` が機能せず、フォルダ20件超でサイドバーがスクロールできなかったバグを修正。
`<aside>` に `min-h-0` を追加することで Flexbox の高さ制限が機能し、スクロールが有効になる。

## 変更内容

- `Sidebar.tsx`: `<aside>` の className に `min-h-0` を追加（バグ修正本体）
- `SidebarScroll.test.tsx`: スクロール機能のリグレッション検知テストを追加（TDD test-first）

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（327件）

## 関連 Issue

closes #14