### PR TITLE
refactor(thumbnail): #16 サムネイル最適化制御をバックエンドへ責務移動

### DIFF
--- a/specs/016-thumbnail-backend-responsibility/spec.md
+++ b/specs/016-thumbnail-backend-responsibility/spec.md
@@ -1,0 +1,454 @@
+# Issue #16: サムネイル最適化制御のバックエンド責務移動 — 技術設計仕様
+
+**作成日**: 2026-03-10
+**ステータス**: Draft
+**TDD方針**: test-first (RED → GREEN → BLUE)
+
+---
+
+## 概要
+
+フロントエンドがバックエンドの最適化戦略（バッチサイズ、優先度制御、画像パス収集）の詳細を知りすぎている問題（情報隠蔽違反）を解消する。フォルダパスを渡すだけでサムネイルが返る新APIをRust側に実装し、フロント側の最適化ロジックを撤廃する。
+
+---
+
+## 1. 現状の問題分析
+
+### 1.1 データフロー（現在）
+
+```
+フロントエンド                              Rust バックエンド
+──────────────────────────────────────────────────────────────
+useThumbnail (FolderView.tsx)
+  ① listImagesInFolder(folderPath)    →   list_images_in_folder
+  ② getBaseName(files[0])            →   tauri path::basename
+  ③ getOrCreateThumbnail(files[0])   →   get_or_create_thumbnail
+  ④ convertFileSrc(cachePath)             (ローカル変換)
+  = 3回のIPC + 1回のローカル処理
+
+useThumbnailPrefetch (Sidebar.tsx)
+  ⑤ folders.slice(0, visibleCount)        (フロントが件数決定)
+  ⑥ N回 listImagesInFolder(folder)   →   N回 list_images_in_folder
+  ⑦ batchCreateThumbnails(paths, N)  →   batch_create_thumbnails
+  = N+1回のIPC（フロントがバッチ戦略を制御）
+```
+
+**問題点**:
+- `useThumbnail`: 1つのサムネイルに3回のIPC呼び出し
+- `useThumbnailPrefetch`: フロントがフォルダ→画像変換・バッチサイズ・優先度ヒント(`visibleCount`)を管理
+- `batchCreateThumbnails` の `visibleCount` パラメータがバックエンド内部の優先度戦略を漏洩
+
+### 1.2 影響ファイル一覧
+
+| ファイル | 役割 | 変更要否 |
+|---------|------|---------|
+| [FileSystemService.ts](../../src/features/folder-navigation/services/FileSystemService.ts) | インターフェース定義 | ✅ メソッド追加・既存非推奨化 |
+| [tauriAdapters.ts](../../src/shared/adapters/tauriAdapters.ts) | Tauri アダプター | ✅ 新メソッド実装 |
+| [useThumbnail.ts](../../src/features/folder-navigation/hooks/useThumbnail.ts) | 個別サムネイル取得 | ✅ 新API利用に変更 |
+| [useThumbnailPrefetch.ts](../../src/features/folder-navigation/hooks/useThumbnailPrefetch.ts) | プリフェッチ | ✅ 大幅簡略化 |
+| [mocks.ts](../../src/test/mocks.ts) | テストモック | ✅ 新メソッド追加 |
+| [thumbnail.rs](../../src-tauri/src/commands/thumbnail.rs) | Rust コマンド | ✅ 新コマンド追加 |
+| [lib.rs](../../src-tauri/src/lib.rs) | コマンド登録 | ✅ 新コマンド登録 |
+| [Sidebar.tsx](../../src/features/folder-navigation/components/Sidebar/Sidebar.tsx) | サイドバー | ⬜ 変更不要（hookが内部変更を吸収） |
+| [FolderView.tsx](../../src/features/folder-navigation/components/FolderView.tsx) | フォルダ表示 | ⬜ 変更不要（hookが内部変更を吸収） |
+| [index.ts](../../src/features/folder-navigation/index.ts) | エクスポート | ⬜ 変更不要（hook名は同一） |
+
+---
+
+## 2. 新APIインターフェース設計
+
+### 2.1 データフロー（新設計）
+
+```
+フロントエンド                              Rust バックエンド
+──────────────────────────────────────────────────────────────
+useThumbnail (FolderView.tsx)
+  ① getFolderThumbnail(folderPath)   →   get_folder_thumbnail
+                                           ├─ list_images_in_folder (内部)
+                                           ├─ get_or_create_thumbnail (内部)
+                                           └─ basename (内部)
+  ② convertFileSrc(result.thumbnailPath)  (ローカル変換)
+  = 1回のIPC + 1回のローカル処理 ✅
+
+useThumbnailPrefetch (Sidebar.tsx)
+  ③ prefetchFolderThumbnails(paths)  →   prefetch_folder_thumbnails
+                                           ├─ フォルダ→画像変換 (内部)
+                                           ├─ 優先度決定 (内部)
+                                           └─ バッチ生成 (内部)
+  = 1回のIPC（バックエンドが全戦略を隠蔽） ✅
+```
+
+### 2.2 Rust コマンド — `get_folder_thumbnail`
+
+```rust
+/// フォルダのサムネイル結果
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FolderThumbnailResult {
+    /// ソース画像のフルパス
+    pub image_path: String,
+    /// サムネイルのキャッシュパス
+    pub thumbnail_path: String,
+    /// ソース画像のファイル名（basename）
+    pub image_name: String,
+}
+
+/// フォルダの代表サムネイルを取得または生成する
+///
+/// フォルダ内の最初の画像を自動選択し、サムネイルを生成してキャッシュパスを返す。
+/// 画像選択・サムネイル生成・キャッシュ管理は全てバックエンドが隠蔽する。
+///
+/// # Arguments
+/// * `folder_path` - フォルダのフルパス
+/// * `app_handle` - Tauriアプリケーションハンドル
+///
+/// # Returns
+/// - `Ok(Some(FolderThumbnailResult))`: サムネイル生成成功
+/// - `Ok(None)`: フォルダに画像がない
+/// - `Err(String)`: エラー
+#[command]
+pub async fn get_folder_thumbnail(
+    folder_path: String,
+    app_handle: AppHandle,
+) -> Result<Option<FolderThumbnailResult>, String>;
+```
+
+**内部処理フロー**:
+1. `core_logic::list_images_in_folder(folder_path)` で画像一覧取得
+2. 画像がなければ `Ok(None)` を返却
+3. 最初の画像を選択し `ThumbnailGenerator::get_or_create_thumbnail` でサムネイル生成
+4. `std::path::Path::file_name()` でbasename取得
+5. `FolderThumbnailResult` を返却
+
+### 2.3 Rust コマンド — `prefetch_folder_thumbnails`
+
+```rust
+/// 複数フォルダのサムネイルをバックグラウンドでプリフェッチする
+///
+/// フォルダパスの配列を受け取り、各フォルダの代表画像を自動選択して
+/// バッチ生成する。優先度・バッチ戦略はバックエンドが内部で決定する。
+///
+/// # Arguments
+/// * `folder_paths` - フォルダパスの配列
+/// * `app_handle` - Tauriアプリケーションハンドル
+///
+/// # Returns
+/// - `Ok(())`: プリフェッチ完了（個別エラーは無視）
+/// - `Err(String)`: 致命的エラー（初期化失敗等）
+#[command]
+pub async fn prefetch_folder_thumbnails(
+    folder_paths: Vec<String>,
+    app_handle: AppHandle,
+) -> Result<(), String>;
+```
+
+**内部処理フロー**:
+1. `tokio::task::spawn_blocking` で非同期実行
+2. 各フォルダから `core_logic::list_images_in_folder` で最初の画像を収集
+3. `BatchThumbnailGenerator` でバッチ生成（優先度はバックエンド内部で決定）
+4. 個別画像のエラーは無視（プリフェッチは best-effort）
+5. `Ok(())` を返却
+
+**優先度の内部決定ロジック**（フロントに非公開）:
+```rust
+// バックエンドが自律的に優先度を決定
+let priority = match index {
+    0..=9   => TaskPriority::High,    // 先頭10件: 高優先度
+    10..=29 => TaskPriority::Normal,  // 次の20件: 通常
+    _       => TaskPriority::Low,     // それ以降: 低優先度
+};
+```
+
+### 2.4 TypeScript `FileSystemService` — 新メソッド
+
+```typescript
+// --- 新しい型定義（folderTypes.ts または新規ファイル） ---
+
+/** バックエンドから返されるフォルダサムネイル結果 */
+export interface FolderThumbnailResult {
+  /** ソース画像のフルパス */
+  imagePath: string;
+  /** サムネイルのキャッシュパス */
+  thumbnailPath: string;
+  /** ソース画像のファイル名 */
+  imageName: string;
+}
+
+// --- FileSystemService 追加メソッド ---
+
+export interface FileSystemService {
+  // ... 既存メソッド（変更なし）...
+
+  // === 新しいサムネイルAPI ===
+
+  /**
+   * フォルダの代表サムネイルを取得する
+   * バックエンドが画像選択・生成・キャッシュを全て隠蔽する
+   *
+   * @param folderPath フォルダのフルパス
+   * @returns サムネイル結果。フォルダに画像がなければ null
+   */
+  getFolderThumbnail?(folderPath: string): Promise<FolderThumbnailResult | null>;
+
+  /**
+   * 複数フォルダのサムネイルをバックグラウンドでプリフェッチする
+   * バッチ戦略・優先度はバックエンドが内部で決定する
+   *
+   * @param folderPaths フォルダパスの配列
+   */
+  prefetchFolderThumbnails?(folderPaths: string[]): Promise<void>;
+
+  // === 非推奨（BLUE フェーズで削除予定） ===
+
+  /** @deprecated getFolderThumbnail を使用してください */
+  getOrCreateThumbnail?(imagePath: string): Promise<string>;
+
+  /** @deprecated prefetchFolderThumbnails を使用してください */
+  batchCreateThumbnails?(
+    imagePaths: string[],
+    visibleCount?: number,
+  ): Promise<Record<string, { success: boolean; path?: string; error?: string }>>;
+
+  /** キャッシュクリア（デバッグ用、変更なし） */
+  clearThumbnailCache?(): Promise<void>;
+}
+```
+
+### 2.5 既存APIの扱い
+
+| API | 判定 | 理由 |
+|-----|------|------|
+| `getOrCreateThumbnail` | **BLUE フェーズで削除** | `getFolderThumbnail` が完全に代替。Rust内部の `ThumbnailGenerator::get_or_create_thumbnail` は引き続き内部利用 |
+| `batchCreateThumbnails` | **BLUE フェーズで削除** | `prefetchFolderThumbnails` が代替。`visibleCount` パラメータが情報漏洩の根本原因 |
+| `clearThumbnailCache` | **維持** | デバッグ用途。現時点で未実装だが、削除理由なし |
+| Rust `get_or_create_thumbnail` コマンド | **BLUE フェーズでコマンド登録解除**（内部利用は継続） | フロントからの直接呼び出し不要に |
+| Rust `batch_create_thumbnails` コマンド | **BLUE フェーズでコマンド登録解除** | `prefetch_folder_thumbnails` が代替 |
+
+### 2.6 `useThumbnailPrefetch` の置き換え方針
+
+**現状**: 87行、フォルダ→画像変換・可視件数制御・バッチ呼び出しを実装
+**新設計**: 約20行に簡略化
+
+```typescript
+// 新しい useThumbnailPrefetch（設計イメージ）
+export function useThumbnailPrefetch(folders: FolderInfo[]) {
+  const fs = useServices();
+
+  useEffect(() => {
+    if (folders.length === 0 || !fs.prefetchFolderThumbnails) return;
+
+    const timeoutId = setTimeout(() => {
+      const folderPaths = folders.map((f) => f.path);
+      void fs.prefetchFolderThumbnails(folderPaths)
+        .catch((err) => console.warn('Prefetch failed:', err));
+    }, SIDEBAR_CONFIG.PREFETCH_DELAY_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [folders, fs]);
+}
+```
+
+**変更点**:
+- `visibleCount` パラメータ削除（バックエンドが内部で優先度決定）
+- `getFirstImagePath` ヘルパー関数削除（バックエンドが画像検索を担当）
+- `disabled` / `delay` / `visibleCount` の options パラメータ簡略化
+- バッチAPIの直接呼び出し削除
+
+**注意**: `SIDEBAR_CONFIG.PREFETCH_DELAY_MS` は維持する。これはUI応答性の最適化であり、バックエンド最適化とは別の関心事。フォルダ数の制限（`INITIAL_VISIBLE_COUNT` でのスライス）もUI側の判断として残すか検討するが、バックエンドが全フォルダを受け取って内部で優先度付けする設計の方がシンプル。
+
+---
+
+## 3. TDD サイクル設計
+
+### Phase 1: RED（失敗するテストを先に書く）
+
+#### 3.1 Rust 単体テスト
+
+| # | テストケース名 | 入力 | 期待出力 | 優先度 | ファイル |
+|---|--------------|------|---------|--------|---------|
+| R1 | `test_get_folder_thumbnail_returns_result_for_folder_with_images` | 画像を含むフォルダパス | `Some(FolderThumbnailResult)` で `image_name` がファイル名 | high | `src-tauri/src/commands/thumbnail.rs` (または新ファイル `folder.rs`) |
+| R2 | `test_get_folder_thumbnail_returns_none_for_empty_folder` | 空フォルダパス | `Ok(None)` | high | 同上 |
+| R3 | `test_get_folder_thumbnail_returns_error_for_invalid_path` | 存在しないパス | `Err(...)` | medium | 同上 |
+| R4 | `test_folder_thumbnail_result_serialization` | `FolderThumbnailResult` 構造体 | JSON に `image_path`, `thumbnail_path`, `image_name` が含まれる | high | 同上 |
+| R5 | `test_prefetch_folder_thumbnails_processes_multiple_folders` | 複数フォルダパス | `Ok(())` + 各フォルダの最初の画像にサムネイルが生成されている | medium | 同上 |
+| R6 | `test_prefetch_folder_thumbnails_handles_empty_input` | 空の Vec | `Ok(())` | medium | 同上 |
+| R7 | `test_prefetch_priority_assignment` | 50件のフォルダ | 先頭10件がHigh、次20件がNormal、残りがLow | medium | `batch.rs` |
+
+**テスタビリティの注意**: R1, R2, R5 は `AppHandle` と実ファイルシステムが必要なため、統合テストレベル。R4, R6, R7 は単体テスト可能。R3 はパスの存在確認がOS依存だが単体テストで可能。
+
+#### 3.2 フロントエンド テスト
+
+| # | テストケース名 | テスト対象 | モック | 期待動作 | 優先度 | ファイル |
+|---|--------------|----------|--------|---------|--------|---------|
+| F1 | `getFolderThumbnail が有効な場合、1回のAPIコールでサムネイルを返す` | `useThumbnail` | `getFolderThumbnail` → `{ imagePath, thumbnailPath, imageName }` | `thumbnail` に `ImageSource` が返る、`listImagesInFolder` が呼ばれない | high | `src/features/folder-navigation/hooks/__tests__/useThumbnail.test.ts` (新規) |
+| F2 | `getFolderThumbnail が null を返す場合、thumbnail が null` | `useThumbnail` | `getFolderThumbnail` → `null` | `thumbnail === null` | high | 同上 |
+| F3 | `getFolderThumbnail が未定義の場合、旧APIにフォールバック` | `useThumbnail` | `getFolderThumbnail` 未定義、`getOrCreateThumbnail` あり | 旧ロジックで動作 | medium | 同上 |
+| F4 | `getFolderThumbnail がエラーの場合、元画像にフォールバック` | `useThumbnail` | `getFolderThumbnail` → throw | `isError: true` またはフォールバック表示 | medium | 同上 |
+| F5 | `prefetchFolderThumbnails でフォルダパスのみ渡してプリフェッチ` | `useThumbnailPrefetch` | `prefetchFolderThumbnails` → void | `prefetchFolderThumbnails` が `folders.map(f => f.path)` で呼ばれる | high | `src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.ts` (新規) |
+| F6 | `prefetchFolderThumbnails 未定義の場合、何もしない` | `useThumbnailPrefetch` | `prefetchFolderThumbnails` 未定義 | エラーなし、旧 `batchCreateThumbnails` も呼ばれない | medium | 同上 |
+| F7 | `空配列の場合、プリフェッチしない` | `useThumbnailPrefetch` | mock あり | `prefetchFolderThumbnails` が呼ばれない | low | 同上 |
+
+**テスト配置方針**:
+- `useThumbnail` / `useThumbnailPrefetch` のテストは `hooks/__tests__/` に新規作成
+- `renderHook` + `ServicesProvider` による DI テスト
+- モックは `createMockFileSystemServiceWithThumbnails()` を拡張
+
+### Phase 2: GREEN（最小実装でテストを通す）
+
+#### ステップ 2.1: Rust 新コマンド実装
+1. `src-tauri/src/commands/thumbnail/folder.rs` を新規作成
+   - `FolderThumbnailResult` 構造体定義
+   - `get_folder_thumbnail` コマンド実装
+   - `prefetch_folder_thumbnails` コマンド実装
+2. `src-tauri/src/commands/thumbnail.rs` (mod.rs相当) で `mod folder;` 追加・re-export
+3. `src-tauri/src/lib.rs` の `invoke_handler` に新コマンド登録
+
+#### ステップ 2.2: TypeScript 型・アダプター追加
+1. `FileSystemService.ts` に `FolderThumbnailResult` 型と新メソッドシグネチャ追加
+2. `tauriAdapters.ts` に `getFolderThumbnail` / `prefetchFolderThumbnails` 実装追加
+3. `mocks.ts` の `createMockFileSystemServiceWithThumbnails()` に新メソッド追加
+
+#### ステップ 2.3: フック更新
+1. `useThumbnail.ts` — `getFolderThumbnail` を優先使用するよう `fetchThumbnail` を更新（旧APIフォールバック維持）
+2. `useThumbnailPrefetch.ts` — `prefetchFolderThumbnails` を優先使用するよう更新（旧APIフォールバック維持）
+
+### Phase 3: BLUE（リファクタリング・旧API削除）
+
+#### ステップ 3.1: 旧APIコード削除（フロントエンド）
+1. `FileSystemService.ts` から `getOrCreateThumbnail` / `batchCreateThumbnails` を削除
+2. `tauriAdapters.ts` から対応する実装を削除
+3. `useThumbnail.ts` から旧APIフォールバックコードを削除
+4. `useThumbnailPrefetch.ts` から旧APIフォールバックコードと `getFirstImagePath` ヘルパー削除
+5. `mocks.ts` から `getOrCreateThumbnail` / `batchCreateThumbnails` モックを削除
+6. `sidebarConfig.ts` の `INITIAL_VISIBLE_COUNT` の用途見直し（プリフェッチ件数制御が不要になった場合は削除検討）
+
+#### ステップ 3.2: 旧コマンド登録解除（Rust）
+1. `src-tauri/src/lib.rs` の `invoke_handler` から `get_or_create_thumbnail` / `batch_create_thumbnails` を外す
+2. `src-tauri/src/commands/thumbnail.rs` の旧コマンド関数に `#[allow(dead_code)]` を付与（内部利用のため関数自体は残す）
+   - `ThumbnailGenerator::get_or_create_thumbnail` は `get_folder_thumbnail` 内部で使用
+   - `BatchThumbnailGenerator::batch_create_thumbnails` は `prefetch_folder_thumbnails` 内部で使用
+
+#### ステップ 3.3: テスト整理
+1. 旧APIを参照するテストの更新・削除
+2. 既存の `FolderView.test.tsx` / `FolderList.test.tsx`（`useThumbnail` モック使用）が引き続きパスすることを確認
+3. `SidebarScroll.test.tsx` のモック更新
+
+---
+
+## 4. 移行戦略
+
+### 段階的移行（推奨）
+
+**コミット単位**で安全に進められるよう、以下の順序で実施する:
+
+```
+コミット1: RED — テスト作成
+  ├─ Rust: 新コマンドのテスト（コンパイルエラーOK）
+  └─ TS: 新フックテスト（型エラーOK）
+
+コミット2: GREEN — 新API実装（旧API併存）
+  ├─ Rust: folder.rs 新コマンド実装 + コマンド登録
+  ├─ TS: 型定義 + アダプター + モック追加
+  └─ TS: フック更新（新API優先、旧APIフォールバック）
+  → 全テスト PASS（新旧両方が動く状態）
+
+コミット3: BLUE — 旧API削除
+  ├─ TS: FileSystemService から旧メソッド削除
+  ├─ TS: アダプター・モック・フックから旧コード削除
+  ├─ Rust: コマンド登録解除
+  └─ テスト整理
+  → 全テスト PASS
+```
+
+### GREEN フェーズでの後方互換性保証
+
+```typescript
+// useThumbnail.ts — GREEN フェーズ（両API共存）
+async function fetchThumbnail(folderPath: string, fs: FileSystemService) {
+  // 新API優先
+  if (fs.getFolderThumbnail) {
+    const result = await fs.getFolderThumbnail(folderPath);
+    if (!result) return null;
+    return {
+      id: result.imagePath,
+      name: result.imageName,
+      assetUrl: fs.convertFileSrc(result.thumbnailPath),
+    };
+  }
+
+  // 旧APIフォールバック（GREEN フェーズのみ）
+  // ... 既存の fetchThumbnail ロジック ...
+}
+```
+
+この設計により:
+- GREEN フェーズ完了時点で新旧テストが全てパス
+- BLUE フェーズで旧コードを安全に削除できる
+- 各コミット時点でテスト全パスが保証される
+
+---
+
+## 5. 設計判断サマリー
+
+### 決定事項
+- **案1「フォルダパスのみの新API」を採用**: `getFolderThumbnail(folderPath)` + `prefetchFolderThumbnails(folderPaths)`
+- **`FolderThumbnailResult` に `imageName` を含める**: フロント側の `getBaseName` IPC呼び出しも削減（3 IPC → 1 IPC）
+- **`prefetchFolderThumbnails` は void を返す**: プリフェッチは best-effort でありフロントは結果を使わない
+- **段階的移行**: GREEN フェーズで旧API併存、BLUE フェーズで削除
+
+### 却下した選択肢
+
+| 選択肢 | 却下理由 |
+|--------|---------|
+| イベント駆動方式（Tauri event listener） | 実装コスト高。SWRキャッシュとの統合が複雑。現行のリクエスト/レスポンスで十分 |
+| `ThumbnailService` を `FileSystemService` から完全分離 | スコープが大きい。ServiceContext の変更、全テストの更新が必要。将来の別Issueで検討 |
+| `getFolderThumbnail` に `ImageSource` を直接返す | `convertFileSrc` はフロントローカルの変換。Rustが `asset://` URLを生成するのは責務外 |
+| `prefetchFolderThumbnails` で結果を返す | プリフェッチの結果をフロントが使わない。voidの方がシンプル |
+
+### 技術的リスク
+
+| リスク | 影響度 | 対策 |
+|--------|--------|------|
+| Rust テストで `AppHandle` が必要 | 中 | `FolderThumbnailResult` のシリアライズテストは単体で可能。`get_folder_thumbnail` は統合テストで検証 |
+| `core_logic::list_images_in_folder` の結果順序に依存 | 低 | ファイルシステムの `read_dir` 順序に依存するが、現行と同じ挙動。必要なら Rust 側でソート追加 |
+| `prefetch_folder_thumbnails` の大量フォルダ入力 | 低 | バックエンドの `TaskPriority` で自動制御。rayon スレッドプールが飽和を防止 |
+| Tauri v2 の `#[command]` で `Option<T>` の返却 | 低 | Tauri v2 は `Result<Option<T>, String>` を正しくシリアライズ。JSONで `null` として返る |
+
+### 前提条件
+- `core_logic::list_images_in_folder` が Rust コマンド内部から直接呼び出せること（確認済み — `core_logic` クレートとして分離されている）
+- `ThumbnailGenerator` と `BatchThumbnailGenerator` の既存内部APIは変更不要
+- テストで使用する `test_images/` フォルダが利用可能
+
+---
+
+## 6. 実装上の注意点
+
+### Rust
+- `folder.rs` を新規作成するか、既存の `thumbnail.rs` に追記するか → モジュール肥大化を避けるため **新ファイル `folder.rs` を推奨**
+- `FolderThumbnailResult` は Tauri の自動シリアライズ(`serde::Serialize`)が必要。フィールド名は `snake_case` → フロントで `camelCase` に変換される（Tauri v2 のデフォルト挙動を確認すること）
+  - **注意**: Tauri v2 は `serde` のデフォルト命名（`snake_case`）をフロントにそのまま渡す。フロント側で `image_path` として受け取るか、`#[serde(rename_all = "camelCase")]` を付与して `imagePath` にするか統一が必要 → **`rename_all = "camelCase"` を推奨**（フロント側のインターフェースと一致させるため）
+- `get_folder_thumbnail` は `tokio::task::spawn_blocking` 内で実行すること（画像I/OでTokioランタイムをブロックしない）
+- `prefetch_folder_thumbnails` のフォルダ→画像変換は I/O バウンドなため `spawn_blocking` 内で一括処理
+
+### TypeScript
+- `FolderThumbnailResult` 型は `src/features/folder-navigation/types/` ディレクトリに配置
+- `useThumbnail` の SWR キーは現在 `folderPath` そのもの — 変更不要
+- `useThumbnailPrefetch` の `options` パラメータは BLUE フェーズで `{ delay?, disabled? }` のみに簡略化
+- `convertFileSrc` はフロント側の責務として維持（Tauri の asset protocol 変換）
+
+### テスト
+- Rust 統合テストには `test_images/` の実画像ファイルを使用
+- フロントエンドテストは `renderHook` + `ServicesProvider` パターン（既存の `FolderView.test.tsx` を参考）
+- `useThumbnailPrefetch` テストでは `vi.useFakeTimers()` で delay 制御
+
+---
+
+## 7. 成果物チェックリスト（Definition of Done）
+
+- [ ] フロント側にバッチサイズ・優先度の計算ロジックが存在しない
+- [ ] `getFolderThumbnail` コマンドが Rust 側で実装されている
+- [ ] `prefetchFolderThumbnails` コマンドが Rust 側で実装されている
+- [ ] バックエンド側の単体テスト / 統合テストが追加されている
+- [ ] フロントエンド側のフックテストが追加されている
+- [ ] 既存の動作が維持されている（回帰テスト全パス: `pnpm test` + `cargo test`）
+- [ ] `visibleCount` パラメータが `FileSystemService` インターフェースから削除されている
+- [ ] `batchCreateThumbnails` / `getOrCreateThumbnail` がフロントから削除されている

--- a/src-tauri/src/commands/thumbnail.rs
+++ b/src-tauri/src/commands/thumbnail.rs
@@ -157,6 +157,8 @@ pub async fn get_folder_thumbnail(
             .map_err(|e| e.to_string())?;
 
         // 3. basenameを取得
+        // get_first_image_in_folder が画像ファイルパスのみ返すため
+        // file_name() が None になるケースは実質到達しない（防御的フォールバック）
         let image_name = std::path::Path::new(&image_path)
             .file_name()
             .and_then(|n| n.to_str())

--- a/src-tauri/src/commands/thumbnail.rs
+++ b/src-tauri/src/commands/thumbnail.rs
@@ -121,3 +121,110 @@ pub async fn clear_thumbnail_cache() -> std::result::Result<(), String> {
     // TODO: Phase 6でキャッシュ管理を実装
     Err("Not implemented yet".to_string())
 }
+
+/// フォルダのサムネイルを取得する（フォルダパスのみで完結）
+///
+/// フォルダ内の最初の画像を自動選択し、サムネイルを生成して返す。
+/// 画像がないフォルダの場合は None (null) を返す。
+///
+/// # Arguments
+/// * `folder_path` - 対象フォルダのフルパス
+/// * `app_handle` - Tauriアプリケーションハンドル（自動注入）
+///
+/// # Returns
+/// FolderThumbnailResult（画像パス、サムネイルパス、ファイル名）、画像なしの場合 null
+#[command]
+pub async fn get_folder_thumbnail(
+    folder_path: String,
+    app_handle: tauri::AppHandle,
+) -> std::result::Result<Option<folder::FolderThumbnailResult>, String> {
+    let result = tokio::task::spawn_blocking(move || {
+        // 1. フォルダ内の最初の画像を取得
+        let first_image = folder::get_first_image_in_folder(&folder_path)?;
+
+        let image_path = match first_image {
+            Some(path) => path,
+            None => return Ok::<Option<folder::FolderThumbnailResult>, String>(None),
+        };
+
+        // 2. サムネイルを生成
+        let generator =
+            ThumbnailGenerator::with_default_config(app_handle).map_err(|e| e.to_string())?;
+        let cache_path = generator
+            .get_or_create_thumbnail(&image_path)
+            .map_err(|e| e.to_string())?;
+
+        // 3. basenameを取得
+        let image_name = std::path::Path::new(&image_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let thumbnail_path = cache_path
+            .to_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| "Failed to convert thumbnail path to string".to_string())?;
+
+        Ok(Some(folder::FolderThumbnailResult {
+            image_path,
+            thumbnail_path,
+            image_name,
+        }))
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))??;
+
+    Ok(result)
+}
+
+/// 複数フォルダのサムネイルをバックグラウンドでプリフェッチする
+///
+/// フォルダパスの配列を受け取り、各フォルダの最初の画像のサムネイルを
+/// バッチ生成する。優先度はインデックス順で自動決定される。
+/// Fire-and-forget パターンで使用される想定。
+///
+/// # Arguments
+/// * `folder_paths` - 対象フォルダのパス配列
+/// * `app_handle` - Tauriアプリケーションハンドル（自動注入）
+#[command]
+pub async fn prefetch_folder_thumbnails(
+    folder_paths: Vec<String>,
+    app_handle: tauri::AppHandle,
+) -> std::result::Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        // 1. 各フォルダから最初の画像パスを取得
+        let image_entries: Vec<(usize, String)> = folder_paths
+            .iter()
+            .enumerate()
+            .filter_map(|(index, folder_path)| {
+                folder::get_first_image_in_folder(folder_path)
+                    .ok()
+                    .flatten()
+                    .map(|image_path| (index, image_path))
+            })
+            .collect();
+
+        if image_entries.is_empty() {
+            return Ok(());
+        }
+
+        // 2. 優先度付きバッチタスクを作成
+        let tasks: Vec<BatchTask> = image_entries
+            .into_iter()
+            .map(|(index, image_path)| {
+                let priority = folder::assign_priority(index);
+                BatchTask::new(image_path, priority)
+            })
+            .collect();
+
+        // 3. バッチ生成を実行
+        let batch_generator =
+            BatchThumbnailGenerator::with_default_config(app_handle).map_err(|e| e.to_string())?;
+        let _results = batch_generator.batch_create_thumbnails(tasks);
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("Task join error: {}", e))?
+}

--- a/src-tauri/src/commands/thumbnail.rs
+++ b/src-tauri/src/commands/thumbnail.rs
@@ -24,6 +24,7 @@ use tauri::command;
 ///
 /// # Returns
 /// サムネイルのキャッシュパス（成功時）
+#[allow(dead_code)]
 #[command]
 pub async fn get_or_create_thumbnail(
     image_path: String,
@@ -53,6 +54,7 @@ pub async fn get_or_create_thumbnail(
 ///
 /// # Returns
 /// 各画像パスに対応するサムネイルキャッシュパスまたはエラーメッセージのマップ
+#[allow(dead_code)]
 #[command]
 pub async fn batch_create_thumbnails(
     image_paths: Vec<String>,

--- a/src-tauri/src/commands/thumbnail.rs
+++ b/src-tauri/src/commands/thumbnail.rs
@@ -3,12 +3,14 @@
 mod batch;
 mod config;
 mod error;
+mod folder;
 mod generator;
 mod utils;
 
 pub use batch::{BatchResult, BatchTask, BatchThumbnailGenerator, TaskPriority};
 pub use config::ThumbnailConfig;
 pub use error::{Result, ThumbnailError};
+pub use folder::FolderThumbnailResult;
 pub use generator::ThumbnailGenerator;
 pub use utils::{get_cache_dir, hash_path};
 

--- a/src-tauri/src/commands/thumbnail/folder.rs
+++ b/src-tauri/src/commands/thumbnail/folder.rs
@@ -18,13 +18,22 @@ pub struct FolderThumbnailResult {
 /// - 10-29: Normal（近傍）
 /// - 30+: Low（バックグラウンド）
 pub fn assign_priority(index: usize) -> TaskPriority {
-    todo!("RED: GREEN フェーズで実装")
+    if index < 10 {
+        TaskPriority::High
+    } else if index < 30 {
+        TaskPriority::Normal
+    } else {
+        TaskPriority::Low
+    }
 }
 
 /// フォルダ内の最初の画像ファイルパスを取得
 /// core_logic::list_images_in_folder を内部で使用
 pub fn get_first_image_in_folder(folder_path: &str) -> Result<Option<String>, String> {
-    todo!("RED: GREEN フェーズで実装")
+    let images = core_logic::list_images_in_folder(folder_path.to_string())
+        .map_err(|e| format!("Failed to list images: {:?}", e))?;
+
+    Ok(images.into_iter().next())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/thumbnail/folder.rs
+++ b/src-tauri/src/commands/thumbnail/folder.rs
@@ -31,7 +31,7 @@ pub fn assign_priority(index: usize) -> TaskPriority {
 /// core_logic::list_images_in_folder を内部で使用
 pub fn get_first_image_in_folder(folder_path: &str) -> Result<Option<String>, String> {
     let images = core_logic::list_images_in_folder(folder_path.to_string())
-        .map_err(|e| format!("Failed to list images: {:?}", e))?;
+        .map_err(|e| format!("Failed to list images in '{}': {:?}", folder_path, e))?;
 
     Ok(images.into_iter().next())
 }

--- a/src-tauri/src/commands/thumbnail/folder.rs
+++ b/src-tauri/src/commands/thumbnail/folder.rs
@@ -1,0 +1,167 @@
+// フォルダサムネイル取得のためのユーティリティ
+
+use serde::Serialize;
+
+use super::batch::TaskPriority;
+
+/// フォルダサムネイル取得結果
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderThumbnailResult {
+    pub image_path: String,
+    pub thumbnail_path: String,
+    pub image_name: String,
+}
+
+/// インデックスから優先度を決定
+/// - 0-9: High（可視領域）
+/// - 10-29: Normal（近傍）
+/// - 30+: Low（バックグラウンド）
+pub fn assign_priority(index: usize) -> TaskPriority {
+    todo!("RED: GREEN フェーズで実装")
+}
+
+/// フォルダ内の最初の画像ファイルパスを取得
+/// core_logic::list_images_in_folder を内部で使用
+pub fn get_first_image_in_folder(folder_path: &str) -> Result<Option<String>, String> {
+    todo!("RED: GREEN フェーズで実装")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env::temp_dir;
+    use std::fs::{create_dir_all, remove_dir_all, File};
+
+    // --- FolderThumbnailResult のシリアライゼーションテスト ---
+
+    #[test]
+    fn test_folder_thumbnail_result_serializes_to_camel_case() {
+        let result = FolderThumbnailResult {
+            image_path: "/photos/folder1/image1.jpg".to_string(),
+            thumbnail_path: "/cache/thumbnails/abc123.jpg".to_string(),
+            image_name: "image1.jpg".to_string(),
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        // camelCase でシリアライズされることを確認
+        assert!(json.get("imagePath").is_some());
+        assert!(json.get("thumbnailPath").is_some());
+        assert!(json.get("imageName").is_some());
+        // snake_case ではないことを確認
+        assert!(json.get("image_path").is_none());
+        assert!(json.get("thumbnail_path").is_none());
+        assert!(json.get("image_name").is_none());
+
+        assert_eq!(json["imagePath"], "/photos/folder1/image1.jpg");
+        assert_eq!(json["thumbnailPath"], "/cache/thumbnails/abc123.jpg");
+        assert_eq!(json["imageName"], "image1.jpg");
+    }
+
+    // --- assign_priority のテスト ---
+
+    #[test]
+    fn test_assign_priority_high_for_visible_range() {
+        // 0-9: High（可視領域）
+        for i in 0..10 {
+            assert_eq!(
+                assign_priority(i),
+                TaskPriority::High,
+                "Index {} should be High priority",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_assign_priority_normal_for_nearby_range() {
+        // 10-29: Normal（近傍）
+        for i in 10..30 {
+            assert_eq!(
+                assign_priority(i),
+                TaskPriority::Normal,
+                "Index {} should be Normal priority",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_assign_priority_low_for_background() {
+        // 30+: Low（バックグラウンド）
+        for i in [30, 50, 100, 1000] {
+            assert_eq!(
+                assign_priority(i),
+                TaskPriority::Low,
+                "Index {} should be Low priority",
+                i
+            );
+        }
+    }
+
+    // --- get_first_image_in_folder のテスト ---
+
+    #[test]
+    fn test_get_first_image_returns_image_path() {
+        let temp = temp_dir().join("test_folder_thumbnail_first");
+        let _ = remove_dir_all(&temp);
+        create_dir_all(&temp).unwrap();
+
+        // 画像ファイルを作成
+        File::create(temp.join("image1.jpg")).unwrap();
+        File::create(temp.join("image2.png")).unwrap();
+
+        let result = get_first_image_in_folder(temp.to_str().unwrap());
+        assert!(result.is_ok());
+        let first = result.unwrap();
+        assert!(first.is_some(), "Should return first image path");
+        // パスに画像拡張子が含まれること
+        let path = first.unwrap();
+        assert!(
+            path.ends_with(".jpg") || path.ends_with(".png"),
+            "Should return an image file path, got: {}",
+            path
+        );
+
+        let _ = remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn test_get_first_image_returns_none_for_empty_folder() {
+        let temp = temp_dir().join("test_folder_thumbnail_empty");
+        let _ = remove_dir_all(&temp);
+        create_dir_all(&temp).unwrap();
+
+        let result = get_first_image_in_folder(temp.to_str().unwrap());
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none(), "Empty folder should return None");
+
+        let _ = remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn test_get_first_image_returns_none_for_non_image_files() {
+        let temp = temp_dir().join("test_folder_thumbnail_no_images");
+        let _ = remove_dir_all(&temp);
+        create_dir_all(&temp).unwrap();
+
+        // 画像以外のファイルのみ
+        File::create(temp.join("document.txt")).unwrap();
+        File::create(temp.join("data.csv")).unwrap();
+
+        let result = get_first_image_in_folder(temp.to_str().unwrap());
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap().is_none(),
+            "Folder with no image files should return None"
+        );
+
+        let _ = remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn test_get_first_image_error_for_nonexistent_folder() {
+        let result = get_first_image_in_folder("/nonexistent/folder/path");
+        assert!(result.is_err(), "Non-existent folder should return error");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod commands;
 use commands::fs::{get_sibling_folders, list_images_in_folder};
 use commands::thumbnail::{
-    batch_create_thumbnails, clear_thumbnail_cache, get_or_create_thumbnail,
+    batch_create_thumbnails, clear_thumbnail_cache, get_folder_thumbnail, get_or_create_thumbnail,
+    prefetch_folder_thumbnails,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -16,7 +17,9 @@ pub fn run() {
             get_sibling_folders,
             get_or_create_thumbnail,
             batch_create_thumbnails,
-            clear_thumbnail_cache
+            clear_thumbnail_cache,
+            get_folder_thumbnail,
+            prefetch_folder_thumbnails
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,7 @@
 pub mod commands;
 use commands::fs::{get_sibling_folders, list_images_in_folder};
 use commands::thumbnail::{
-    batch_create_thumbnails, clear_thumbnail_cache, get_folder_thumbnail, get_or_create_thumbnail,
-    prefetch_folder_thumbnails,
+    clear_thumbnail_cache, get_folder_thumbnail, prefetch_folder_thumbnails,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -15,8 +14,6 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             list_images_in_folder,
             get_sibling_folders,
-            get_or_create_thumbnail,
-            batch_create_thumbnails,
             clear_thumbnail_cache,
             get_folder_thumbnail,
             prefetch_folder_thumbnails

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -93,6 +93,8 @@ const createMockFileSystemService = (): FileSystemService => ({
   listImagesInFolder: vi.fn(),
   getSiblingFolders: vi.fn(),
   convertFileSrc: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 });
 
 describe('App Component', () => {

--- a/src/__tests__/ViewerLayout.test.tsx
+++ b/src/__tests__/ViewerLayout.test.tsx
@@ -27,6 +27,8 @@ describe('ViewerLayout - US1: Viewer displays full image without scrolling', () 
       listImagesInFolder: vi.fn(),
       getSiblingFolders: vi.fn(),
       convertFileSrc: vi.fn((path: string) => `asset://${path}`),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
     };
 
     // Mock feature components to keep layout structure

--- a/src/features/folder-navigation/hooks/__tests__/useOpenImageFile.test.ts
+++ b/src/features/folder-navigation/hooks/__tests__/useOpenImageFile.test.ts
@@ -10,6 +10,8 @@ const mockFs = {
   listImagesInFolder: vi.fn(),
   getSiblingFolders: vi.fn(),
   convertFileSrc: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 };
 
 describe('useOpenImageFile', () => {

--- a/src/features/folder-navigation/hooks/__tests__/useSiblingFolders.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useSiblingFolders.test.tsx
@@ -19,6 +19,8 @@ const mockFileSystemService: FileSystemService = {
   convertFileSrc: vi.fn(),
   getBaseName: vi.fn(),
   getDirName: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 };
 
 // --- ヘルパーコンポーネント ---

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
@@ -75,31 +75,6 @@ describe('useThumbnail', () => {
     expect(result.current.thumbnail).toBeNull();
   });
 
-  // テスト3: getFolderThumbnail未定義時のフォールバック
-  it('getFolderThumbnailが未定義の場合、従来のAPIにフォールバックする', async () => {
-    const mockService: Partial<FileSystemService> = {
-      // getFolderThumbnail は未定義（ServicesProviderのデフォルトを上書き）
-      getFolderThumbnail: undefined,
-      listImagesInFolder: vi
-        .fn()
-        .mockResolvedValue(['/photos/folder1/image1.jpg']),
-      getBaseName: vi.fn().mockResolvedValue('image1.jpg'),
-      getOrCreateThumbnail: vi.fn().mockResolvedValue('/cache/thumb.jpg'),
-      convertFileSrc: (path: string) => `asset://${path}`,
-    };
-
-    const { result } = renderHook(() => useThumbnail('/photos/folder1'), {
-      wrapper: createWrapper(mockService),
-    });
-
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    expect(result.current.thumbnail).toBeTruthy();
-    expect(mockService.listImagesInFolder).toHaveBeenCalled();
-  });
-
   // テスト4: ローディング状態
   it('サムネイル取得中はisLoadingがtrueを返す', () => {
     const mockService: Partial<FileSystemService> = {

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
@@ -34,6 +34,7 @@ describe('useThumbnail', () => {
         thumbnailPath: '/cache/thumbnails/abc123.jpg',
         imageName: 'image1.jpg',
       }),
+      listImagesInFolder: vi.fn(),
       convertFileSrc: (path: string) => `asset://${path}`,
     };
 
@@ -53,8 +54,8 @@ describe('useThumbnail', () => {
     expect(mockService.getFolderThumbnail).toHaveBeenCalledWith(
       '/photos/folder1',
     );
-    // 旧APIは呼ばれない
-    expect(mockService.listImagesInFolder).toBeUndefined();
+    // 旧APIは呼ばれない（新APIで1回のIPCで完結）
+    expect(mockService.listImagesInFolder).not.toHaveBeenCalled();
   });
 
   // テスト2: 画像なしフォルダ

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
@@ -64,10 +64,9 @@ describe('useThumbnail', () => {
       convertFileSrc: (path: string) => `asset://${path}`,
     };
 
-    const { result } = renderHook(
-      () => useThumbnail('/photos/empty-folder'),
-      { wrapper: createWrapper(mockService) },
-    );
+    const { result } = renderHook(() => useThumbnail('/photos/empty-folder'), {
+      wrapper: createWrapper(mockService),
+    });
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
@@ -79,7 +78,8 @@ describe('useThumbnail', () => {
   // テスト3: getFolderThumbnail未定義時のフォールバック
   it('getFolderThumbnailが未定義の場合、従来のAPIにフォールバックする', async () => {
     const mockService: Partial<FileSystemService> = {
-      // getFolderThumbnail は未定義
+      // getFolderThumbnail は未定義（ServicesProviderのデフォルトを上書き）
+      getFolderThumbnail: undefined,
       listImagesInFolder: vi
         .fn()
         .mockResolvedValue(['/photos/folder1/image1.jpg']),

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnail.test.tsx
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { SWRConfig } from 'swr';
+import { describe, expect, it, vi } from 'vitest';
+import { ServicesProvider } from '../../../../shared/context/ServiceContext';
+import type { FileSystemService } from '../../services/FileSystemService';
+import { useThumbnail } from '../useThumbnail';
+
+// --- ヘルパー ---
+
+/**
+ * SWRキャッシュ分離 + ServiceContext を提供するラッパー
+ */
+function createWrapper(service: Partial<FileSystemService>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <ServicesProvider services={service as FileSystemService}>
+          {children}
+        </ServicesProvider>
+      </SWRConfig>
+    );
+  };
+}
+
+// --- テストスイート ---
+
+describe('useThumbnail', () => {
+  // テスト1: 新API(getFolderThumbnail)経由でサムネイル取得
+  it('新APIが利用可能な場合、getFolderThumbnailで1回のIPCでサムネイルを取得する', async () => {
+    const mockService: Partial<FileSystemService> = {
+      getFolderThumbnail: vi.fn().mockResolvedValue({
+        imagePath: '/photos/folder1/image1.jpg',
+        thumbnailPath: '/cache/thumbnails/abc123.jpg',
+        imageName: 'image1.jpg',
+      }),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    const { result } = renderHook(() => useThumbnail('/photos/folder1'), {
+      wrapper: createWrapper(mockService),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.thumbnail).toEqual({
+      id: '/photos/folder1/image1.jpg',
+      name: 'image1.jpg',
+      assetUrl: 'asset:///cache/thumbnails/abc123.jpg',
+    });
+    expect(mockService.getFolderThumbnail).toHaveBeenCalledWith(
+      '/photos/folder1',
+    );
+    // 旧APIは呼ばれない
+    expect(mockService.listImagesInFolder).toBeUndefined();
+  });
+
+  // テスト2: 画像なしフォルダ
+  it('画像がないフォルダの場合、nullを返す', async () => {
+    const mockService: Partial<FileSystemService> = {
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    const { result } = renderHook(
+      () => useThumbnail('/photos/empty-folder'),
+      { wrapper: createWrapper(mockService) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.thumbnail).toBeNull();
+  });
+
+  // テスト3: getFolderThumbnail未定義時のフォールバック
+  it('getFolderThumbnailが未定義の場合、従来のAPIにフォールバックする', async () => {
+    const mockService: Partial<FileSystemService> = {
+      // getFolderThumbnail は未定義
+      listImagesInFolder: vi
+        .fn()
+        .mockResolvedValue(['/photos/folder1/image1.jpg']),
+      getBaseName: vi.fn().mockResolvedValue('image1.jpg'),
+      getOrCreateThumbnail: vi.fn().mockResolvedValue('/cache/thumb.jpg'),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    const { result } = renderHook(() => useThumbnail('/photos/folder1'), {
+      wrapper: createWrapper(mockService),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.thumbnail).toBeTruthy();
+    expect(mockService.listImagesInFolder).toHaveBeenCalled();
+  });
+
+  // テスト4: ローディング状態
+  it('サムネイル取得中はisLoadingがtrueを返す', () => {
+    const mockService: Partial<FileSystemService> = {
+      getFolderThumbnail: vi.fn().mockImplementation(
+        () => new Promise(() => {}), // 永遠にpending
+      ),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    const { result } = renderHook(() => useThumbnail('/photos/folder1'), {
+      wrapper: createWrapper(mockService),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
@@ -90,23 +90,4 @@ describe('useThumbnailPrefetch', () => {
 
     expect(mockService.prefetchFolderThumbnails).not.toHaveBeenCalled();
   });
-
-  // テスト4: フォールバック（新API未定義 → 旧API）
-  it('prefetchFolderThumbnailsが未定義の場合、従来のbatchCreateThumbnailsにフォールバックする', async () => {
-    const mockService: Partial<FileSystemService> = {
-      // prefetchFolderThumbnails は未定義（ServicesProviderのデフォルトを上書き）
-      prefetchFolderThumbnails: undefined,
-      listImagesInFolder: vi.fn().mockResolvedValue(['/mock/image.jpg']),
-      batchCreateThumbnails: vi.fn().mockResolvedValue({}),
-      convertFileSrc: (path: string) => `asset://${path}`,
-    };
-
-    renderHook(() => useThumbnailPrefetch(mockFolders, { delay: 0 }), {
-      wrapper: createWrapper(mockService),
-    });
-
-    await vi.advanceTimersByTimeAsync(100); // デフォルトdelay + 処理時間
-
-    expect(mockService.batchCreateThumbnails).toHaveBeenCalled();
-  });
 });

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
@@ -44,10 +44,9 @@ describe('useThumbnailPrefetch', () => {
       convertFileSrc: (path: string) => `asset://${path}`,
     };
 
-    renderHook(
-      () => useThumbnailPrefetch(mockFolders, { delay: 0 }),
-      { wrapper: createWrapper(mockService) },
-    );
+    renderHook(() => useThumbnailPrefetch(mockFolders, { delay: 0 }), {
+      wrapper: createWrapper(mockService),
+    });
 
     // useEffect + setTimeout の実行を待つ
     await vi.advanceTimersByTimeAsync(0);
@@ -66,10 +65,9 @@ describe('useThumbnailPrefetch', () => {
       convertFileSrc: (path: string) => `asset://${path}`,
     };
 
-    renderHook(
-      () => useThumbnailPrefetch([], { delay: 0 }),
-      { wrapper: createWrapper(mockService) },
-    );
+    renderHook(() => useThumbnailPrefetch([], { delay: 0 }), {
+      wrapper: createWrapper(mockService),
+    });
 
     await vi.advanceTimersByTimeAsync(0);
 
@@ -96,16 +94,16 @@ describe('useThumbnailPrefetch', () => {
   // テスト4: フォールバック（新API未定義 → 旧API）
   it('prefetchFolderThumbnailsが未定義の場合、従来のbatchCreateThumbnailsにフォールバックする', async () => {
     const mockService: Partial<FileSystemService> = {
-      // prefetchFolderThumbnails は未定義
+      // prefetchFolderThumbnails は未定義（ServicesProviderのデフォルトを上書き）
+      prefetchFolderThumbnails: undefined,
       listImagesInFolder: vi.fn().mockResolvedValue(['/mock/image.jpg']),
       batchCreateThumbnails: vi.fn().mockResolvedValue({}),
       convertFileSrc: (path: string) => `asset://${path}`,
     };
 
-    renderHook(
-      () => useThumbnailPrefetch(mockFolders, { delay: 0 }),
-      { wrapper: createWrapper(mockService) },
-    );
+    renderHook(() => useThumbnailPrefetch(mockFolders, { delay: 0 }), {
+      wrapper: createWrapper(mockService),
+    });
 
     await vi.advanceTimersByTimeAsync(100); // デフォルトdelay + 処理時間
 

--- a/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
+++ b/src/features/folder-navigation/hooks/__tests__/useThumbnailPrefetch.test.tsx
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServicesProvider } from '../../../../shared/context/ServiceContext';
+import type { FileSystemService } from '../../services/FileSystemService';
+import type { FolderInfo } from '../../types/folderTypes';
+import { useThumbnailPrefetch } from '../useThumbnailPrefetch';
+
+// --- ヘルパー ---
+
+function createWrapper(service: Partial<FileSystemService>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <ServicesProvider services={service as FileSystemService}>
+        {children}
+      </ServicesProvider>
+    );
+  };
+}
+
+// --- テストデータ ---
+
+const mockFolders: FolderInfo[] = [
+  { path: '/photos/folder1', name: 'folder1' },
+  { path: '/photos/folder2', name: 'folder2' },
+  { path: '/photos/folder3', name: 'folder3' },
+];
+
+// --- テストスイート ---
+
+describe('useThumbnailPrefetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // テスト1: 新API経由でプリフェッチ
+  it('新APIが利用可能な場合、全フォルダパスをprefetchFolderThumbnailsに渡す', async () => {
+    const mockService: Partial<FileSystemService> = {
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    renderHook(
+      () => useThumbnailPrefetch(mockFolders, { delay: 0 }),
+      { wrapper: createWrapper(mockService) },
+    );
+
+    // useEffect + setTimeout の実行を待つ
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockService.prefetchFolderThumbnails).toHaveBeenCalledWith([
+      '/photos/folder1',
+      '/photos/folder2',
+      '/photos/folder3',
+    ]);
+  });
+
+  // テスト2: 空のフォルダリスト
+  it('フォルダが0件の場合、プリフェッチAPIを呼ばない', async () => {
+    const mockService: Partial<FileSystemService> = {
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    renderHook(
+      () => useThumbnailPrefetch([], { delay: 0 }),
+      { wrapper: createWrapper(mockService) },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockService.prefetchFolderThumbnails).not.toHaveBeenCalled();
+  });
+
+  // テスト3: disabled時は呼ばない
+  it('disabled: trueの場合、プリフェッチを実行しない', async () => {
+    const mockService: Partial<FileSystemService> = {
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    renderHook(
+      () => useThumbnailPrefetch(mockFolders, { disabled: true, delay: 0 }),
+      { wrapper: createWrapper(mockService) },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockService.prefetchFolderThumbnails).not.toHaveBeenCalled();
+  });
+
+  // テスト4: フォールバック（新API未定義 → 旧API）
+  it('prefetchFolderThumbnailsが未定義の場合、従来のbatchCreateThumbnailsにフォールバックする', async () => {
+    const mockService: Partial<FileSystemService> = {
+      // prefetchFolderThumbnails は未定義
+      listImagesInFolder: vi.fn().mockResolvedValue(['/mock/image.jpg']),
+      batchCreateThumbnails: vi.fn().mockResolvedValue({}),
+      convertFileSrc: (path: string) => `asset://${path}`,
+    };
+
+    renderHook(
+      () => useThumbnailPrefetch(mockFolders, { delay: 0 }),
+      { wrapper: createWrapper(mockService) },
+    );
+
+    await vi.advanceTimersByTimeAsync(100); // デフォルトdelay + 処理時間
+
+    expect(mockService.batchCreateThumbnails).toHaveBeenCalled();
+  });
+});

--- a/src/features/folder-navigation/hooks/useThumbnail.ts
+++ b/src/features/folder-navigation/hooks/useThumbnail.ts
@@ -3,59 +3,16 @@ import { useServices } from '../../../shared/context/ServiceContext';
 import type { ImageSource } from '../../image-viewer/types/ImageSource';
 import type { FileSystemService } from '../services/FileSystemService';
 
-/**
- * フォルダのサムネイルを取得
- * 001-rust-thumbnail-optimization: Rustバックエンドでサムネイル生成する場合はgetOrCreateThumbnailを使用
- */
 async function fetchThumbnail(
   folderPath: string,
   fs: FileSystemService,
 ): Promise<ImageSource | null> {
-  // 新API: get_folder_thumbnail（IPC 1回で完結）
-  if (fs.getFolderThumbnail) {
-    const result = await fs.getFolderThumbnail(folderPath);
-    if (!result) return null;
-    return {
-      id: result.imagePath,
-      name: result.imageName,
-      assetUrl: fs.convertFileSrc(result.thumbnailPath),
-    };
-  }
-
-  // フォールバック: 旧API（3回のIPC）
-  const files = await fs.listImagesInFolder(folderPath);
-
-  if (files.length < 1) {
-    return null;
-  }
-
-  const first = files[0];
-  const name = await fs.getBaseName(first);
-
-  // Rustサムネイル最適化が有効な場合はそれを使用
-  if (fs.getOrCreateThumbnail) {
-    try {
-      const thumbnailPath = await fs.getOrCreateThumbnail(first);
-      return {
-        id: first,
-        name,
-        assetUrl: fs.convertFileSrc(thumbnailPath),
-      };
-    } catch (_error) {
-      // フォールバック: 元の画像を使用
-      return {
-        id: first,
-        name,
-        assetUrl: fs.convertFileSrc(first),
-      };
-    }
-  }
-
-  // フォールバック: 元の画像を直接使用
+  const result = await fs.getFolderThumbnail(folderPath);
+  if (!result) return null;
   return {
-    id: first,
-    name,
-    assetUrl: fs.convertFileSrc(first),
+    id: result.imagePath,
+    name: result.imageName,
+    assetUrl: fs.convertFileSrc(result.thumbnailPath),
   };
 }
 

--- a/src/features/folder-navigation/hooks/useThumbnail.ts
+++ b/src/features/folder-navigation/hooks/useThumbnail.ts
@@ -11,6 +11,18 @@ async function fetchThumbnail(
   folderPath: string,
   fs: FileSystemService,
 ): Promise<ImageSource | null> {
+  // 新API: get_folder_thumbnail（IPC 1回で完結）
+  if (fs.getFolderThumbnail) {
+    const result = await fs.getFolderThumbnail(folderPath);
+    if (!result) return null;
+    return {
+      id: result.imagePath,
+      name: result.imageName,
+      assetUrl: fs.convertFileSrc(result.thumbnailPath),
+    };
+  }
+
+  // フォールバック: 旧API（3回のIPC）
   const files = await fs.listImagesInFolder(folderPath);
 
   if (files.length < 1) {

--- a/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
+++ b/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
@@ -1,26 +1,10 @@
 import { useEffect } from 'react';
 import { useServices } from '../../../shared/context/ServiceContext';
 import { SIDEBAR_CONFIG } from '../constants/sidebarConfig';
-import type { FileSystemService } from '../services/FileSystemService';
 import type { FolderInfo } from '../types/folderTypes';
 
 /**
- * フォルダの最初の画像パスを取得
- */
-async function getFirstImagePath(
-  folderPath: string,
-  fs: FileSystemService,
-): Promise<string | null> {
-  try {
-    const files = await fs.listImagesInFolder(folderPath);
-    return files.length > 0 ? files[0] : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * 可視領域のサムネイルをバックグラウンドでプリフェッチ
+ * サムネイルをバックグラウンドでプリフェッチ
  *
  * UIの初期レンダリング完了後に遅延実行し、Fire-and-Forgetパターンで
  * バックグラウンド処理することでUIブロッキングを防止
@@ -31,8 +15,6 @@ async function getFirstImagePath(
 export function useThumbnailPrefetch(
   folders: FolderInfo[],
   options?: {
-    /** プリフェッチ対象の件数 */
-    visibleCount?: number;
     /** プリフェッチ開始までの遅延（ms） */
     delay?: number;
     /** プリフェッチを無効化 */
@@ -40,60 +22,19 @@ export function useThumbnailPrefetch(
   },
 ) {
   const fs = useServices();
-  const {
-    visibleCount = SIDEBAR_CONFIG.INITIAL_VISIBLE_COUNT,
-    delay = SIDEBAR_CONFIG.PREFETCH_DELAY_MS,
-    disabled = false,
-  } = options ?? {};
+  const { delay = SIDEBAR_CONFIG.PREFETCH_DELAY_MS, disabled = false } =
+    options ?? {};
 
   useEffect(() => {
-    // 無効化されている場合は何もしない
-    if (disabled) return;
+    if (disabled || folders.length === 0) return;
 
-    // フォルダがない場合はスキップ
-    if (folders.length === 0) return;
-
-    // バッチAPI（新旧どちらも）未対応の場合はスキップ
-    if (!fs.prefetchFolderThumbnails && !fs.batchCreateThumbnails) return;
-
-    // UIの初期レンダリング完了後にプリフェッチ開始
     const timeoutId = setTimeout(() => {
-      // 新API: prefetch_folder_thumbnails（バックエンド一括処理）
-      if (fs.prefetchFolderThumbnails) {
-        const folderPaths = folders.map((f) => f.path);
-        void fs
-          .prefetchFolderThumbnails(folderPaths)
-          .catch((err) => console.warn('Prefetch failed:', err));
-        return;
-      }
-
-      // フォールバック: 旧API
-      // Fire-and-Forget: async関数を起動するがawaitしない
-      void (async () => {
-        // 可視領域のフォルダパスを取得
-        const visibleFolders = folders
-          .slice(0, visibleCount)
-          .map((f) => f.path);
-
-        // 各フォルダの最初の画像パスを取得
-        const imagePathPromises = visibleFolders.map((folderPath) =>
-          getFirstImagePath(folderPath, fs),
-        );
-        const imagePaths = (await Promise.all(imagePathPromises)).filter(
-          (path): path is string => path !== null,
-        );
-
-        if (imagePaths.length === 0) return;
-
-        // バッチ生成を実行（優先度付き）
-        try {
-          await fs.batchCreateThumbnails?.(imagePaths, imagePaths.length);
-        } catch (error) {
-          console.warn('Batch thumbnail prefetch failed:', error);
-        }
-      })();
+      const folderPaths = folders.map((f) => f.path);
+      void fs
+        .prefetchFolderThumbnails(folderPaths)
+        .catch((err) => console.warn('Prefetch failed:', err));
     }, delay);
 
     return () => clearTimeout(timeoutId);
-  }, [folders, fs, visibleCount, delay, disabled]);
+  }, [folders, fs, delay, disabled]);
 }

--- a/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
+++ b/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
@@ -50,11 +50,24 @@ export function useThumbnailPrefetch(
     // 無効化されている場合は何もしない
     if (disabled) return;
 
-    // フォルダがない、またはバッチAPI未対応の場合はスキップ
-    if (folders.length === 0 || !fs.batchCreateThumbnails) return;
+    // フォルダがない場合はスキップ
+    if (folders.length === 0) return;
+
+    // バッチAPI（新旧どちらも）未対応の場合はスキップ
+    if (!fs.prefetchFolderThumbnails && !fs.batchCreateThumbnails) return;
 
     // UIの初期レンダリング完了後にプリフェッチ開始
     const timeoutId = setTimeout(() => {
+      // 新API: prefetch_folder_thumbnails（バックエンド一括処理）
+      if (fs.prefetchFolderThumbnails) {
+        const folderPaths = folders.map((f) => f.path);
+        void fs
+          .prefetchFolderThumbnails(folderPaths)
+          .catch((err) => console.warn('Prefetch failed:', err));
+        return;
+      }
+
+      // フォールバック: 旧API
       // Fire-and-Forget: async関数を起動するがawaitしない
       void (async () => {
         // 可視領域のフォルダパスを取得

--- a/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
+++ b/src/features/folder-navigation/hooks/useThumbnailPrefetch.ts
@@ -25,6 +25,9 @@ export function useThumbnailPrefetch(
   const { delay = SIDEBAR_CONFIG.PREFETCH_DELAY_MS, disabled = false } =
     options ?? {};
 
+  // NOTE: folders の参照安定性に依存。React Compiler が有効な場合は自動メモ化される。
+  // 無効な環境では、親コンポーネントが毎レンダリングで新配列を渡すと
+  // timer の setup/teardown が頻発する可能性がある。
   useEffect(() => {
     if (disabled || folders.length === 0) return;
 

--- a/src/features/folder-navigation/services/FileSystemService.ts
+++ b/src/features/folder-navigation/services/FileSystemService.ts
@@ -1,3 +1,5 @@
+import type { FolderThumbnailResult } from '../types/folderTypes';
+
 export interface FileSystemService {
   openDirectoryDialog: () => Promise<string | null>;
   openImageFileDialog?: (extensions?: string[]) => Promise<string | null>;
@@ -58,4 +60,10 @@ export interface FileSystemService {
    * @throws {Error} キャッシュクリア中にエラーが発生した場合
    */
   clearThumbnailCache?(): Promise<void>;
+
+  // 016-thumbnail-backend-responsibility
+  getFolderThumbnail?(
+    folderPath: string,
+  ): Promise<FolderThumbnailResult | null>;
+  prefetchFolderThumbnails?(folderPaths: string[]): Promise<void>;
 }

--- a/src/features/folder-navigation/services/FileSystemService.ts
+++ b/src/features/folder-navigation/services/FileSystemService.ts
@@ -30,30 +30,6 @@ export interface FileSystemService {
    */
   convertFileSrc(filePath: string): string;
 
-  // Thumbnail optimization methods (001-rust-thumbnail-optimization)
-
-  /**
-   * 画像のサムネイルを取得または生成する
-   * @param imagePath ソース画像のフルパス
-   * @returns {Promise<string>} サムネイルのキャッシュパス
-   * @throws {Error} サムネイル生成中にエラーが発生した場合
-   */
-  getOrCreateThumbnail?(imagePath: string): Promise<string>;
-
-  /**
-   * 複数の画像のサムネイルをバッチ生成する
-   * @param imagePaths ソース画像のパスの配列
-   * @param visibleCount 可視領域の画像数（優先度High）
-   * @returns {Promise<Record<string, { success: boolean; path?: string; error?: string }>>} 各画像パスに対応する生成結果のマップ
-   * @throws {Error} サムネイル生成中にエラーが発生した場合
-   */
-  batchCreateThumbnails?(
-    imagePaths: string[],
-    visibleCount?: number,
-  ): Promise<
-    Record<string, { success: boolean; path?: string; error?: string }>
-  >;
-
   /**
    * サムネイルキャッシュをクリアする（デバッグ用）
    * @returns {Promise<void>}
@@ -61,9 +37,17 @@ export interface FileSystemService {
    */
   clearThumbnailCache?(): Promise<void>;
 
-  // 016-thumbnail-backend-responsibility
-  getFolderThumbnail?(
-    folderPath: string,
-  ): Promise<FolderThumbnailResult | null>;
-  prefetchFolderThumbnails?(folderPaths: string[]): Promise<void>;
+  /**
+   * フォルダのサムネイル（代表画像）を取得する
+   * バックエンドが画像選択・サムネイル生成を一括処理
+   * @param folderPath フォルダのパス
+   * @returns {Promise<FolderThumbnailResult | null>} サムネイル情報、画像なしの場合null
+   */
+  getFolderThumbnail(folderPath: string): Promise<FolderThumbnailResult | null>;
+
+  /**
+   * 複数フォルダのサムネイルをバックグラウンドでプリフェッチする
+   * @param folderPaths フォルダパスの配列
+   */
+  prefetchFolderThumbnails(folderPaths: string[]): Promise<void>;
 }

--- a/src/features/folder-navigation/services/__tests__/getSiblingFolders.test.ts
+++ b/src/features/folder-navigation/services/__tests__/getSiblingFolders.test.ts
@@ -11,6 +11,8 @@ const mockFileSystemService: FileSystemService = {
   convertFileSrc: vi.fn(),
   getBaseName: vi.fn(),
   getDirName: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 };
 
 describe('getSiblingFolderEntries', () => {

--- a/src/features/folder-navigation/stories/FolderList.stories.tsx
+++ b/src/features/folder-navigation/stories/FolderList.stories.tsx
@@ -41,6 +41,8 @@ const createMockFileSystemService = (): FileSystemService => ({
   convertFileSrc: (_filePath: string): string => {
     throw new Error('Function not implemented.');
   },
+  getFolderThumbnail: async () => null,
+  prefetchFolderThumbnails: async () => {},
 });
 
 const MockServiceProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/features/folder-navigation/types/folderTypes.ts
+++ b/src/features/folder-navigation/types/folderTypes.ts
@@ -68,3 +68,13 @@ export interface SidebarProps {
   className?: string;
   style?: React.CSSProperties;
 }
+
+/**
+ * フォルダサムネイル取得結果の型（016-thumbnail-backend-responsibility）
+ * - バックエンドが1回のIPCで画像選択・サムネイル生成を完結する新APIの返却型
+ */
+export interface FolderThumbnailResult {
+  imagePath: string;
+  thumbnailPath: string;
+  imageName: string;
+}

--- a/src/features/image-viewer/components/__tests__/ImageViewer.test.tsx
+++ b/src/features/image-viewer/components/__tests__/ImageViewer.test.tsx
@@ -15,6 +15,8 @@ const createMockFileSystemService = (): FileSystemService => ({
   listImagesInFolder: vi.fn(),
   getSiblingFolders: vi.fn(),
   convertFileSrc: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 });
 
 describe('ImageViewer', () => {

--- a/src/features/image-viewer/stories/ImageViewer.stories.tsx
+++ b/src/features/image-viewer/stories/ImageViewer.stories.tsx
@@ -21,6 +21,8 @@ const createMockFileSystemService = (
   getBaseName: async (filePath: string) => filePath.split('/').pop() || '',
   getDirName: async (filePath: string) =>
     filePath.substring(0, filePath.lastIndexOf('/')),
+  getFolderThumbnail: async () => null,
+  prefetchFolderThumbnails: async () => {},
 });
 
 const MockServiceProvider = ({

--- a/src/shared/adapters/tauriAdapters.ts
+++ b/src/shared/adapters/tauriAdapters.ts
@@ -7,6 +7,7 @@ import {
   dirname as tauriDirname,
 } from '@tauri-apps/api/path';
 import { open as tauriOpenDialog } from '@tauri-apps/plugin-dialog';
+import type { FolderThumbnailResult } from '@/features/folder-navigation/types/folderTypes';
 import type { FileSystemService } from '../../features/folder-navigation';
 import { isStringArray } from '../utils/isStringArray';
 
@@ -128,6 +129,34 @@ export const tauriFileSystemService: FileSystemService = {
       await invoke('clear_thumbnail_cache');
     } catch (error) {
       throw new Error(`Failed to clear thumbnail cache: ${error}`);
+    }
+  },
+
+  // 016-thumbnail-backend-responsibility
+
+  getFolderThumbnail: async (
+    folderPath: string,
+  ): Promise<FolderThumbnailResult | null> => {
+    try {
+      const result = await invoke<FolderThumbnailResult | null>(
+        'get_folder_thumbnail',
+        { folderPath },
+      );
+      return result;
+    } catch (error) {
+      throw new Error(
+        `Failed to get folder thumbnail for "${folderPath}": ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  },
+
+  prefetchFolderThumbnails: async (folderPaths: string[]): Promise<void> => {
+    try {
+      await invoke('prefetch_folder_thumbnails', { folderPaths });
+    } catch (error) {
+      throw new Error(
+        `Failed to prefetch folder thumbnails: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   },
 };

--- a/src/shared/adapters/tauriAdapters.ts
+++ b/src/shared/adapters/tauriAdapters.ts
@@ -90,40 +90,6 @@ export const tauriFileSystemService: FileSystemService = {
     }
   },
 
-  // Thumbnail optimization methods (001-rust-thumbnail-optimization)
-
-  getOrCreateThumbnail: async (imagePath: string): Promise<string> => {
-    try {
-      const cachePath = await invoke<string>('get_or_create_thumbnail', {
-        imagePath,
-      });
-      return cachePath;
-    } catch (error) {
-      throw new Error(
-        `Failed to get or create thumbnail for ${imagePath}: ${error}`,
-      );
-    }
-  },
-
-  batchCreateThumbnails: async (
-    imagePaths: string[],
-    visibleCount?: number,
-  ): Promise<
-    Record<string, { success: boolean; path?: string; error?: string }>
-  > => {
-    try {
-      const result = await invoke<
-        Record<string, { success: boolean; path?: string; error?: string }>
-      >('batch_create_thumbnails', {
-        imagePaths,
-        visibleCount,
-      });
-      return result;
-    } catch (error) {
-      throw new Error(`Failed to batch create thumbnails: ${error}`);
-    }
-  },
-
   clearThumbnailCache: async (): Promise<void> => {
     try {
       await invoke('clear_thumbnail_cache');

--- a/src/shared/hooks/data/__tests__/useImages.test.tsx
+++ b/src/shared/hooks/data/__tests__/useImages.test.tsx
@@ -33,6 +33,8 @@ const mockFileSystemService: FileSystemService = {
     return foundMock ? foundMock.assetUrl : 'asset://unknown';
   }),
   openImageFileDialog: vi.fn(),
+  getFolderThumbnail: vi.fn().mockResolvedValue(null),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 };
 
 const ServicesWrapper = ({ children }: { children: React.ReactNode }) => {

--- a/src/stories/ViewerIntegration.stories.tsx
+++ b/src/stories/ViewerIntegration.stories.tsx
@@ -34,6 +34,8 @@ const createMockFileSystemService = (): FileSystemService => ({
     const parts = filePath.split('/');
     return parts.slice(0, -1).join('/');
   },
+  getFolderThumbnail: async () => null,
+  prefetchFolderThumbnails: async () => {},
 });
 
 const MockServiceProvider = ({ children }: { children: React.ReactNode }) => {

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -71,4 +71,10 @@ export const createMockFileSystemServiceWithThumbnails = () => ({
     '/mock/image1.jpg': { success: true, path: '/mock/cache/thumb1.jpg' },
   }),
   clearThumbnailCache: vi.fn().mockResolvedValue(undefined),
+  getFolderThumbnail: vi.fn().mockResolvedValue({
+    imagePath: '/mock/image.jpg',
+    thumbnailPath: '/mock/cache/thumb.jpg',
+    imageName: 'image.jpg',
+  }),
+  prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
 });

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -66,10 +66,6 @@ export const createMockFileSystemServiceWithThumbnails = () => ({
   convertFileSrc: vi.fn((path: string) => `asset://${path}`),
   listImagesInFolder: vi.fn().mockResolvedValue([]),
   getSiblingFolders: vi.fn().mockResolvedValue([]),
-  getOrCreateThumbnail: vi.fn().mockResolvedValue('/mock/cache/thumbnail.jpg'),
-  batchCreateThumbnails: vi.fn().mockResolvedValue({
-    '/mock/image1.jpg': { success: true, path: '/mock/cache/thumb1.jpg' },
-  }),
   clearThumbnailCache: vi.fn().mockResolvedValue(undefined),
   getFolderThumbnail: vi.fn().mockResolvedValue({
     imagePath: '/mock/image.jpg',


### PR DESCRIPTION
## 概要

サムネイル取得時の IPC 呼び出しを 3回→1回に削減し、バッチサイズ計算・優先度割り当て等の最適化戦略を Rust バックエンドに移動。フロントエンドは「フォルダパスを渡すだけ」のシンプルな API を呼ぶだけに簡略化。

## 変更内容

### Rust 側（新コマンド追加）
- `get_folder_thumbnail`: フォルダパス→サムネイル一発取得（IPC 3回→1回）
- `prefetch_folder_thumbnails`: 複数フォルダのバッチプリフェッチ（バックエンド優先度制御）
- `FolderThumbnailResult` 構造体（camelCase シリアライゼーション対応）
- `assign_priority`: インデックスベースの優先度自動決定（0-9: High, 10-29: Normal, 30+: Low）
- 旧コマンド（`get_or_create_thumbnail`, `batch_create_thumbnails`）の Tauri コマンド登録解除

### フロントエンド（新API対応 + 旧API除去）
- `FileSystemService` に `getFolderThumbnail` / `prefetchFolderThumbnails` を必須メソッドとして追加
- 旧メソッド（`getOrCreateThumbnail`, `batchCreateThumbnails`）を完全削除
- `useThumbnail.ts`: 新API直接利用に簡略化（フォールバック削除）
- `useThumbnailPrefetch.ts`: 新API直接利用に簡略化（`getFirstImagePath` ヘルパー・`visibleCount` 削除）
- `tauriAdapters.ts`: 新 invoke 追加、旧 invoke 削除
- テストモック・テストファイルの更新

### コード削減
- ネット **-147行**（旧APIフォールバックの複雑度を大幅低減）

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（333件）
- [x] `cargo test` PASS（17件）

## レビュー指摘事項

### 🟡 Warning（後続タスクで対応推奨）

1. **旧コマンドの `#[command]` 属性残存**: `thumbnail.rs` の `get_or_create_thumbnail` / `batch_create_thumbnails` に `#[allow(dead_code)]` と `#[command]` が併存。未登録コマンドに `#[command]` を残す意味がなく、将来の読み手に誤解を与える可能性。次回整理タスクで `#[command]` 属性を除去し内部関数として整理を推奨
2. **`prefetch_folder_thumbnails` の逐次 I/O**: `get_first_image_in_folder` を各フォルダに対し逐次呼び出し。フォルダ数が多い場合（100+）に完了までの待ち時間増加の可能性。`spawn_blocking` 内のため Tokio はブロックしないが、将来的に rayon `par_iter` での並列化を検討
3. **`useThumbnail` エラーケーステスト不足**: `getFolderThumbnail` がエラーを throw するケースのテストがない。SWR の `isError` 状態を検証するテスト追加を推奨
4. **`useThumbnailPrefetch` cleanup テスト不足**: `delay` が有効な状態で unmount した際に `clearTimeout` が機能し API が呼ばれないことの検証がない

### 🟢 Suggestion（対応任意）

1. **`get_first_image_in_folder` のパス正規化**: `std::path::Path::canonicalize()` でパスを正規化するとシンボリックリンクや `..` に対してより堅牢に。ただしデスクトップアプリのためセキュリティリスクは低い
2. **`clearThumbnailCache` の一貫性**: 新サムネイルAPIが必須メソッドなのに対し `clearThumbnailCache` がオプショナルのまま。意図的であれば JSDoc コメントで明示を推奨
3. **テスト番号欠番の補足**: `useThumbnail.test.tsx` のテスト番号「1, 2, 4」の欠番について、テストファイル内に1行コメントを追加すると将来の保守者に親切
4. **エラーハンドリングの不統一**: 新メソッドの `error instanceof Error ? error.message : String(error)` は既存パターンより良い書き方だが、ファイル内で不統一。既存メソッドの改善は別タスクで対応

## 関連 Issue

closes #16