### PR TITLE
refactor(app-shell): #17 handleMenuActionをCommand Registryパターンへ移行

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useTransition } from 'react';
 import './App.css';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useTheme } from './components/theme-provider';
-import { AppMenuBar, type AppMenuBarEvent } from './features/app-shell';
+import { AppMenuBar, useAppActions } from './features/app-shell';
 import {
   type FolderInfo,
   Sidebar,
@@ -55,50 +55,16 @@ function App({ initialState }: { initialState?: Partial<AppState> }) {
   const fss = useServices();
   const { openImageFile } = useOpenImageFile(fss);
 
-  const handleMenuAction = async (actionId: AppMenuBarEvent) => {
-    // TODO: スケールを考えてストラテジーパターンへの移行を検討
-    try {
-      if (actionId === 'open-folder') {
-        const folderPath = await fss.openDirectoryDialog();
-        if (folderPath) {
-          startTransition(() => {
-            setAppState((prev) => ({
-              ...prev,
-              currentFolderPath: folderPath,
-              initialImageIndex: 0,
-            }));
-          });
-        }
-      } else if (actionId === 'open-image') {
-        const result = await openImageFile();
-        if (result?.folderPath) {
-          startTransition(() => {
-            setAppState((prev) => ({
-              ...prev,
-              currentFolderPath: result.folderPath || '',
-              initialImageIndex: result.index,
-            }));
-          });
-        }
-      } else if (actionId === 'toggle-theme') {
-        try {
-          // useTheme is used below via closure; safe to call outside because hook must be used in component scope
-          const { theme: currentTheme, setTheme } = themeApi;
+  // Command Registry パターンによるメニューアクション処理
+  const { executeAction } = useAppActions({
+    fss,
+    openImageFile,
+    themeApi,
+    startTransition,
+    setAppState,
+  });
 
-          // テーマの切り替えルールを関数として純粋に定義（light/darkのみ）
-          const getOppositeTheme = (current: typeof currentTheme) =>
-            current === 'dark' ? 'light' : 'dark';
-
-          setTheme(getOppositeTheme(currentTheme));
-        } catch (err) {
-          console.error('toggle-theme failed', err);
-        }
-      }
-      // 他のアクションは今まで通り（必要ならここに追加）
-    } catch (error) {
-      console.error('Menu action failed:', error);
-    }
-  };
+  const handleMenuAction = executeAction;
 
   const handleFolderSelect = (folder: FolderInfo) => {
     startTransition(() => {

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -14,27 +14,31 @@ const mockOpenImageFile = vi.fn();
 
 // Mock the feature components
 // For testing rendering App's children and their interactions
-vi.mock('../features/app-shell', () => ({
-  AppMenuBar: ({ onMenuAction, isDraggable }: AppMenuBarProps) => (
-    <div data-testid="app-menu-bar" data-draggable={isDraggable}>
-      {/* For testing parameter 'onMenuAction' handling */}
-      <button
-        type="button"
-        data-testid="open-folder-btn"
-        onClick={() => onMenuAction('open-folder')}
-      >
-        Open Folder
-      </button>
-      <button
-        type="button"
-        data-testid="open-image-btn"
-        onClick={() => onMenuAction('open-image')}
-      >
-        Open Image
-      </button>
-    </div>
-  ),
-}));
+vi.mock('../features/app-shell', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../features/app-shell')>();
+  return {
+    ...actual,
+    AppMenuBar: ({ onMenuAction, isDraggable }: AppMenuBarProps) => (
+      <div data-testid="app-menu-bar" data-draggable={isDraggable}>
+        {/* For testing parameter 'onMenuAction' handling */}
+        <button
+          type="button"
+          data-testid="open-folder-btn"
+          onClick={() => onMenuAction('open-folder')}
+        >
+          Open Folder
+        </button>
+        <button
+          type="button"
+          data-testid="open-image-btn"
+          onClick={() => onMenuAction('open-image')}
+        >
+          Open Image
+        </button>
+      </div>
+    ),
+  };
+});
 
 vi.mock('../features/folder-navigation', () => ({
   Sidebar: ({

--- a/src/__tests__/ViewerLayout.test.tsx
+++ b/src/__tests__/ViewerLayout.test.tsx
@@ -32,19 +32,24 @@ describe('ViewerLayout - US1: Viewer displays full image without scrolling', () 
     };
 
     // Mock feature components to keep layout structure
-    vi.mock('@/features/app-shell', () => ({
-      AppMenuBar: ({ onMenuAction, isDraggable }: any) => (
-        <div data-testid="app-menu-bar" data-draggable={isDraggable}>
-          <button
-            type="button"
-            data-testid="open-folder-btn"
-            onClick={() => onMenuAction('open-folder')}
-          >
-            Open Folder
-          </button>
-        </div>
-      ),
-    }));
+    vi.mock('@/features/app-shell', async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import('@/features/app-shell')>();
+      return {
+        ...actual,
+        AppMenuBar: ({ onMenuAction, isDraggable }: any) => (
+          <div data-testid="app-menu-bar" data-draggable={isDraggable}>
+            <button
+              type="button"
+              data-testid="open-folder-btn"
+              onClick={() => onMenuAction('open-folder')}
+            >
+              Open Folder
+            </button>
+          </div>
+        ),
+      };
+    });
 
     vi.mock('@/features/folder-navigation', () => ({
       Sidebar: ({ folders, selectedFolder, onFolderSelect, width }: any) => (

--- a/src/features/app-shell/__tests__/helpers.ts
+++ b/src/features/app-shell/__tests__/helpers.ts
@@ -1,0 +1,24 @@
+import { vi } from 'vitest';
+import type { ActionContext } from '../actions/types';
+
+export function createMockContext(
+  overrides?: Partial<ActionContext>,
+): ActionContext {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    themeApi: { theme: 'dark', setTheme: vi.fn() },
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    ...overrides,
+  };
+}

--- a/src/features/app-shell/actions/__tests__/actionRegistry.test.ts
+++ b/src/features/app-shell/actions/__tests__/actionRegistry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createActionRegistry } from '../actionRegistry';
+import { openFolderAction } from '../openFolderAction';
+import { openImageAction } from '../openImageAction';
+import { toggleThemeAction } from '../toggleThemeAction';
+
+describe('createActionRegistry', () => {
+  it('registers 3 actions', () => {
+    const registry = createActionRegistry();
+
+    expect(registry.size).toBe(3);
+  });
+
+  it('maps open-folder to openFolderAction', () => {
+    const registry = createActionRegistry();
+
+    expect(registry.get('open-folder')).toBe(openFolderAction);
+  });
+
+  it('maps open-image to openImageAction', () => {
+    const registry = createActionRegistry();
+
+    expect(registry.get('open-image')).toBe(openImageAction);
+  });
+
+  it('maps toggle-theme to toggleThemeAction', () => {
+    const registry = createActionRegistry();
+
+    expect(registry.get('toggle-theme')).toBe(toggleThemeAction);
+  });
+});

--- a/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openFolderAction } from '../openFolderAction';
+import type { ActionContext } from '../types';
+
+function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    themeApi: { theme: 'dark', setTheme: vi.fn() },
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('openFolderAction', () => {
+  let ctx: ActionContext;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+  });
+
+  it('calls setAppState via startTransition when dialog returns a path', async () => {
+    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/some/folder');
+
+    await openFolderAction(ctx);
+
+    expect(ctx.startTransition).toHaveBeenCalledOnce();
+    expect(ctx.setAppState).toHaveBeenCalledOnce();
+  });
+
+  it('sets currentFolderPath and initialImageIndex: 0', async () => {
+    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/some/folder');
+
+    await openFolderAction(ctx);
+
+    const updater = vi.mocked(ctx.setAppState).mock.calls[0][0];
+    // updater is a callback; invoke it with a dummy prev state
+    const prev = { currentFolderPath: '', initialImageIndex: 5 };
+    const next =
+      typeof updater === 'function' ? updater(prev as never) : updater;
+
+    expect(next).toEqual(
+      expect.objectContaining({
+        currentFolderPath: '/some/folder',
+        initialImageIndex: 0,
+      }),
+    );
+  });
+
+  it('does not call setAppState when dialog is cancelled (null)', async () => {
+    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue(null);
+
+    await openFolderAction(ctx);
+
+    expect(ctx.setAppState).not.toHaveBeenCalled();
+    expect(ctx.startTransition).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
@@ -1,26 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../../__tests__/helpers';
 import { openFolderAction } from '../openFolderAction';
 import type { ActionContext } from '../types';
-
-function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
-  return {
-    fss: {
-      openDirectoryDialog: vi.fn().mockResolvedValue(null),
-      getBaseName: vi.fn(),
-      getDirName: vi.fn(),
-      listImagesInFolder: vi.fn(),
-      getSiblingFolders: vi.fn(),
-      convertFileSrc: vi.fn(),
-      getFolderThumbnail: vi.fn().mockResolvedValue(null),
-      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
-    },
-    openImageFile: vi.fn().mockResolvedValue(null),
-    themeApi: { theme: 'dark', setTheme: vi.fn() },
-    startTransition: vi.fn((cb: () => void) => cb()),
-    setAppState: vi.fn(),
-    ...overrides,
-  };
-}
 
 describe('openFolderAction', () => {
   let ctx: ActionContext;

--- a/src/features/app-shell/actions/__tests__/openImageAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openImageAction.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openImageAction } from '../openImageAction';
+import type { ActionContext } from '../types';
+
+function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    themeApi: { theme: 'dark', setTheme: vi.fn() },
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('openImageAction', () => {
+  let ctx: ActionContext;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+  });
+
+  it('calls setAppState via startTransition when openImageFile returns a result', async () => {
+    vi.mocked(ctx.openImageFile).mockResolvedValue({
+      folderPath: '/images',
+      filePath: '/images/pic.png',
+      index: 3,
+    });
+
+    await openImageAction(ctx);
+
+    expect(ctx.startTransition).toHaveBeenCalledOnce();
+    expect(ctx.setAppState).toHaveBeenCalledOnce();
+  });
+
+  it('passes folderPath and index from the result to setAppState', async () => {
+    vi.mocked(ctx.openImageFile).mockResolvedValue({
+      folderPath: '/images/photos',
+      filePath: '/images/photos/img.jpg',
+      index: 7,
+    });
+
+    await openImageAction(ctx);
+
+    const updater = vi.mocked(ctx.setAppState).mock.calls[0][0];
+    const prev = { currentFolderPath: '', initialImageIndex: 0 };
+    const next =
+      typeof updater === 'function' ? updater(prev as never) : updater;
+
+    expect(next).toEqual(
+      expect.objectContaining({
+        currentFolderPath: '/images/photos',
+        initialImageIndex: 7,
+      }),
+    );
+  });
+
+  it('does not call setAppState when openImageFile returns null', async () => {
+    vi.mocked(ctx.openImageFile).mockResolvedValue(null);
+
+    await openImageAction(ctx);
+
+    expect(ctx.setAppState).not.toHaveBeenCalled();
+    expect(ctx.startTransition).not.toHaveBeenCalled();
+  });
+
+  it('does not call setAppState when result has falsy folderPath', async () => {
+    vi.mocked(ctx.openImageFile).mockResolvedValue({
+      folderPath: '',
+      filePath: null,
+      index: 0,
+    });
+
+    await openImageAction(ctx);
+
+    expect(ctx.setAppState).not.toHaveBeenCalled();
+    expect(ctx.startTransition).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/app-shell/actions/__tests__/openImageAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openImageAction.test.ts
@@ -1,26 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../../__tests__/helpers';
 import { openImageAction } from '../openImageAction';
 import type { ActionContext } from '../types';
-
-function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
-  return {
-    fss: {
-      openDirectoryDialog: vi.fn().mockResolvedValue(null),
-      getBaseName: vi.fn(),
-      getDirName: vi.fn(),
-      listImagesInFolder: vi.fn(),
-      getSiblingFolders: vi.fn(),
-      convertFileSrc: vi.fn(),
-      getFolderThumbnail: vi.fn().mockResolvedValue(null),
-      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
-    },
-    openImageFile: vi.fn().mockResolvedValue(null),
-    themeApi: { theme: 'dark', setTheme: vi.fn() },
-    startTransition: vi.fn((cb: () => void) => cb()),
-    setAppState: vi.fn(),
-    ...overrides,
-  };
-}
 
 describe('openImageAction', () => {
   let ctx: ActionContext;

--- a/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
@@ -1,26 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../../__tests__/helpers';
 import { toggleThemeAction } from '../toggleThemeAction';
 import type { ActionContext } from '../types';
-
-function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
-  return {
-    fss: {
-      openDirectoryDialog: vi.fn().mockResolvedValue(null),
-      getBaseName: vi.fn(),
-      getDirName: vi.fn(),
-      listImagesInFolder: vi.fn(),
-      getSiblingFolders: vi.fn(),
-      convertFileSrc: vi.fn(),
-      getFolderThumbnail: vi.fn().mockResolvedValue(null),
-      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
-    },
-    openImageFile: vi.fn().mockResolvedValue(null),
-    themeApi: { theme: 'dark', setTheme: vi.fn() },
-    startTransition: vi.fn((cb: () => void) => cb()),
-    setAppState: vi.fn(),
-    ...overrides,
-  };
-}
 
 describe('toggleThemeAction', () => {
   let ctx: ActionContext;

--- a/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toggleThemeAction } from '../toggleThemeAction';
+import type { ActionContext } from '../types';
+
+function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    themeApi: { theme: 'dark', setTheme: vi.fn() },
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('toggleThemeAction', () => {
+  let ctx: ActionContext;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+  });
+
+  it('switches from dark to light', async () => {
+    ctx = createMockContext({ themeApi: { theme: 'dark', setTheme: vi.fn() } });
+
+    await toggleThemeAction(ctx);
+
+    expect(ctx.themeApi.setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('switches from light to dark', async () => {
+    ctx = createMockContext({
+      themeApi: { theme: 'light', setTheme: vi.fn() },
+    });
+
+    await toggleThemeAction(ctx);
+
+    expect(ctx.themeApi.setTheme).toHaveBeenCalledWith('dark');
+  });
+});

--- a/src/features/app-shell/actions/actionRegistry.ts
+++ b/src/features/app-shell/actions/actionRegistry.ts
@@ -1,0 +1,16 @@
+import type { AppMenuBarEvent } from '../components/AppMenuBar';
+import { openFolderAction } from './openFolderAction';
+import { openImageAction } from './openImageAction';
+import { toggleThemeAction } from './toggleThemeAction';
+import type { ActionHandler } from './types';
+
+/**
+ * 全アクションハンドラーを登録する Map を生成。
+ */
+export function createActionRegistry(): Map<AppMenuBarEvent, ActionHandler> {
+  return new Map<AppMenuBarEvent, ActionHandler>([
+    ['open-folder', openFolderAction],
+    ['open-image', openImageAction],
+    ['toggle-theme', toggleThemeAction],
+  ]);
+}

--- a/src/features/app-shell/actions/actionRegistry.ts
+++ b/src/features/app-shell/actions/actionRegistry.ts
@@ -1,14 +1,13 @@
-import type { AppMenuBarEvent } from '../components/AppMenuBar';
 import { openFolderAction } from './openFolderAction';
 import { openImageAction } from './openImageAction';
 import { toggleThemeAction } from './toggleThemeAction';
-import type { ActionHandler } from './types';
+import type { ActionRegistry } from './types';
 
 /**
  * 全アクションハンドラーを登録する Map を生成。
  */
-export function createActionRegistry(): Map<AppMenuBarEvent, ActionHandler> {
-  return new Map<AppMenuBarEvent, ActionHandler>([
+export function createActionRegistry(): ActionRegistry {
+  return new Map([
     ['open-folder', openFolderAction],
     ['open-image', openImageAction],
     ['toggle-theme', toggleThemeAction],

--- a/src/features/app-shell/actions/index.ts
+++ b/src/features/app-shell/actions/index.ts
@@ -1,0 +1,2 @@
+export { createActionRegistry } from './actionRegistry';
+export type { ActionContext, ActionHandler, ActionRegistry } from './types';

--- a/src/features/app-shell/actions/openFolderAction.ts
+++ b/src/features/app-shell/actions/openFolderAction.ts
@@ -1,0 +1,14 @@
+import type { ActionHandler } from './types';
+
+export const openFolderAction: ActionHandler = async (ctx) => {
+  const folderPath = await ctx.fss.openDirectoryDialog();
+  if (folderPath) {
+    ctx.startTransition(() => {
+      ctx.setAppState((prev) => ({
+        ...prev,
+        currentFolderPath: folderPath,
+        initialImageIndex: 0,
+      }));
+    });
+  }
+};

--- a/src/features/app-shell/actions/openImageAction.ts
+++ b/src/features/app-shell/actions/openImageAction.ts
@@ -2,11 +2,12 @@ import type { ActionHandler } from './types';
 
 export const openImageAction: ActionHandler = async (ctx) => {
   const result = await ctx.openImageFile();
-  if (result?.folderPath) {
+  const folderPath = result?.folderPath;
+  if (folderPath) {
     ctx.startTransition(() => {
       ctx.setAppState((prev) => ({
         ...prev,
-        currentFolderPath: result.folderPath || '',
+        currentFolderPath: folderPath,
         initialImageIndex: result.index,
       }));
     });

--- a/src/features/app-shell/actions/openImageAction.ts
+++ b/src/features/app-shell/actions/openImageAction.ts
@@ -1,0 +1,14 @@
+import type { ActionHandler } from './types';
+
+export const openImageAction: ActionHandler = async (ctx) => {
+  const result = await ctx.openImageFile();
+  if (result?.folderPath) {
+    ctx.startTransition(() => {
+      ctx.setAppState((prev) => ({
+        ...prev,
+        currentFolderPath: result.folderPath || '',
+        initialImageIndex: result.index,
+      }));
+    });
+  }
+};

--- a/src/features/app-shell/actions/toggleThemeAction.ts
+++ b/src/features/app-shell/actions/toggleThemeAction.ts
@@ -1,0 +1,7 @@
+import type { ActionHandler } from './types';
+
+export const toggleThemeAction: ActionHandler = async (ctx) => {
+  const { theme: currentTheme, setTheme } = ctx.themeApi;
+  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  setTheme(nextTheme);
+};

--- a/src/features/app-shell/actions/types.ts
+++ b/src/features/app-shell/actions/types.ts
@@ -1,0 +1,29 @@
+import type { AppState } from '@/App';
+import type { OpenImageFileResult } from '@/features/folder-navigation/hooks/useOpenImageFile';
+import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
+import type { AppMenuBarEvent } from '../components/AppMenuBar';
+
+/**
+ * アクションハンドラーが受け取るコンテキスト。
+ * App コンポーネントが持つ依存を集約したもの。
+ */
+export interface ActionContext {
+  fss: FileSystemService;
+  openImageFile: () => Promise<OpenImageFileResult | null>;
+  themeApi: {
+    theme: 'dark' | 'light';
+    setTheme: (theme: 'dark' | 'light') => void;
+  };
+  startTransition: (callback: () => void) => void;
+  setAppState: React.Dispatch<React.SetStateAction<AppState>>;
+}
+
+/**
+ * 個別アクションハンドラーの型。
+ */
+export type ActionHandler = (context: ActionContext) => Promise<void>;
+
+/**
+ * アクション ID → ハンドラー関数の Map 型。
+ */
+export type ActionRegistry = Map<AppMenuBarEvent, ActionHandler>;

--- a/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
+++ b/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActionContext } from '../../actions/types';
+import { useAppActions } from '../useAppActions';
+
+function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    themeApi: { theme: 'dark', setTheme: vi.fn() },
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useAppActions', () => {
+  let ctx: ActionContext;
+
+  beforeEach(() => {
+    ctx = createMockContext();
+  });
+
+  it('executeAction invokes the registered handler', async () => {
+    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/test');
+
+    const { result } = renderHook(() => useAppActions(ctx));
+
+    await result.current.executeAction('open-folder');
+
+    expect(ctx.fss.openDirectoryDialog).toHaveBeenCalledOnce();
+    expect(ctx.setAppState).toHaveBeenCalledOnce();
+  });
+
+  it('warns on unregistered action id', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAppActions(ctx));
+
+    // 'exit' is a valid AppMenuBarEvent but not registered in the registry
+    await result.current.executeAction('exit');
+
+    expect(warnSpy).toHaveBeenCalledWith('Unhandled menu action: exit');
+    warnSpy.mockRestore();
+  });
+
+  it('catches handler errors and logs them with console.error', async () => {
+    const error = new Error('boom');
+    vi.mocked(ctx.fss.openDirectoryDialog).mockRejectedValue(error);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAppActions(ctx));
+    await result.current.executeAction('open-folder');
+
+    expect(errorSpy).toHaveBeenCalledWith('Menu action failed:', error);
+    errorSpy.mockRestore();
+  });
+});

--- a/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
+++ b/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
@@ -1,27 +1,8 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockContext } from '../../__tests__/helpers';
 import type { ActionContext } from '../../actions/types';
 import { useAppActions } from '../useAppActions';
-
-function createMockContext(overrides?: Partial<ActionContext>): ActionContext {
-  return {
-    fss: {
-      openDirectoryDialog: vi.fn().mockResolvedValue(null),
-      getBaseName: vi.fn(),
-      getDirName: vi.fn(),
-      listImagesInFolder: vi.fn(),
-      getSiblingFolders: vi.fn(),
-      convertFileSrc: vi.fn(),
-      getFolderThumbnail: vi.fn().mockResolvedValue(null),
-      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
-    },
-    openImageFile: vi.fn().mockResolvedValue(null),
-    themeApi: { theme: 'dark', setTheme: vi.fn() },
-    startTransition: vi.fn((cb: () => void) => cb()),
-    setAppState: vi.fn(),
-    ...overrides,
-  };
-}
 
 describe('useAppActions', () => {
   let ctx: ActionContext;
@@ -62,7 +43,10 @@ describe('useAppActions', () => {
     const { result } = renderHook(() => useAppActions(ctx));
     await result.current.executeAction('open-folder');
 
-    expect(errorSpy).toHaveBeenCalledWith('Menu action failed:', error);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Menu action failed [open-folder]:',
+      error,
+    );
     errorSpy.mockRestore();
   });
 });

--- a/src/features/app-shell/hooks/useAppActions.ts
+++ b/src/features/app-shell/hooks/useAppActions.ts
@@ -1,15 +1,14 @@
-import { useMemo } from 'react';
 import { createActionRegistry } from '../actions/actionRegistry';
 import type { ActionContext } from '../actions/types';
 import type { AppMenuBarEvent } from '../components/AppMenuBar';
+
+const registry = createActionRegistry();
 
 interface UseAppActionsReturn {
   executeAction: (actionId: AppMenuBarEvent) => Promise<void>;
 }
 
 export function useAppActions(context: ActionContext): UseAppActionsReturn {
-  const registry = useMemo(() => createActionRegistry(), []);
-
   const executeAction = async (actionId: AppMenuBarEvent) => {
     const handler = registry.get(actionId);
     if (!handler) {
@@ -19,7 +18,7 @@ export function useAppActions(context: ActionContext): UseAppActionsReturn {
     try {
       await handler(context);
     } catch (error) {
-      console.error('Menu action failed:', error);
+      console.error(`Menu action failed [${actionId}]:`, error);
     }
   };
 

--- a/src/features/app-shell/hooks/useAppActions.ts
+++ b/src/features/app-shell/hooks/useAppActions.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import { createActionRegistry } from '../actions/actionRegistry';
+import type { ActionContext } from '../actions/types';
+import type { AppMenuBarEvent } from '../components/AppMenuBar';
+
+interface UseAppActionsReturn {
+  executeAction: (actionId: AppMenuBarEvent) => Promise<void>;
+}
+
+export function useAppActions(context: ActionContext): UseAppActionsReturn {
+  const registry = useMemo(() => createActionRegistry(), []);
+
+  const executeAction = async (actionId: AppMenuBarEvent) => {
+    const handler = registry.get(actionId);
+    if (!handler) {
+      console.warn(`Unhandled menu action: ${actionId}`);
+      return;
+    }
+    try {
+      await handler(context);
+    } catch (error) {
+      console.error('Menu action failed:', error);
+    }
+  };
+
+  return { executeAction };
+}

--- a/src/features/app-shell/index.ts
+++ b/src/features/app-shell/index.ts
@@ -1,5 +1,7 @@
 // App Shell Feature Exports
 
+// Actions
+export type { ActionContext, ActionHandler, ActionRegistry } from './actions';
 export type {
   AppMenuBarEvent,
   AppMenuBarProps,
@@ -11,7 +13,8 @@ export { HeaderMenu } from './components/HeaderMenu';
 export { KeyboardShortcutHelp } from './components/KeyboardShortcutHelp';
 export { MenuDropdown } from './components/MenuDropdown';
 export { MenuItem } from './components/MenuItem';
-
+// Hooks
+export { useAppActions } from './hooks/useAppActions';
 // Settings
 export {
   createCustomKeyboardMapping,


### PR DESCRIPTION
## 概要

`App.tsx` の `handleMenuAction` が if-else 連鎖（40行）で肥大化していたため、Command Registry パターンへ移行。各アクションを純粋な async 関数として独立分離し、`useAppActions` フック経由で実行する構造に変更。

## 変更内容

- `App.tsx` の if-else 連鎖（40行）を `useAppActions` フック呼び出し（4行）に置換
- 各アクション（`openFolderAction`, `openImageAction`, `toggleThemeAction`）を独立した純粋関数として分離
- `ActionRegistry`（Map）によるアクションID → ハンドラー紐付け
- `ActionContext` インターフェースで依存を注入するパターンを導入
- 新規単体テスト16ケース追加（アクション / レジストリ / フック）
- 既存テストのモックを `importOriginal` パターンに更新

### 新規ファイル
- `src/features/app-shell/actions/types.ts` — ActionContext, ActionHandler, ActionRegistry 型定義
- `src/features/app-shell/actions/openFolderAction.ts` — フォルダ開くアクション
- `src/features/app-shell/actions/openImageAction.ts` — 画像開くアクション
- `src/features/app-shell/actions/toggleThemeAction.ts` — テーマ切替アクション
- `src/features/app-shell/actions/actionRegistry.ts` — アクション登録 Map 生成
- `src/features/app-shell/actions/index.ts` — バレルエクスポート
- `src/features/app-shell/hooks/useAppActions.ts` — useAppActions フック
- `src/features/app-shell/__tests__/helpers.ts` — 共通テストヘルパー（`createMockContext`）

### 更新ファイル
- `src/App.tsx` — handleMenuAction を useAppActions 経由に変更
- `src/features/app-shell/index.ts` — エクスポート追加
- `src/__tests__/App.test.tsx` — モックを importOriginal パターンに更新
- `src/__tests__/ViewerLayout.test.tsx` — 同上

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（349件）

## Copilot レビュー指摘への対応（2nd commit: dc71621）

Copilot レビューで指摘された8件すべてに対応済み:

| # | 指摘 | 対応 |
|---|------|------|
| 1 | `console.error` に `actionId` を含めるべき | `actionId` をログメッセージに追加 |
| 2 | `actionRegistry` 戻り値型を `ActionRegistry` に統一 | 型エイリアスに変更 |
| 3 | `openImageAction` の `\|\| ''` が冗長 | フォールバック除去 |
| 4-7 | `createMockContext` が4テストで重複 | `__tests__/helpers.ts` に共通ヘルパーとして抽出 |
| 8 | `useMemo` 不要（静的 Map） | モジュールスコープで1回のみ生成に変更 |

## Senior Reviewer レビュー結果

- 🔴 Critical: 0件
- 🟡 Warning: 0件
- 🟢 Suggestion: 3件（以下参考情報）

1. `createMockContext` のシャローマージ特性: 現状問題なし。deep merge が必要になった時点で対応
2. モジュールスコープ `registry` のイミュータブル性: 現設計で問題なし（YAGNI）
3. `toggleThemeAction` の不要な `async`: `ActionHandler` 型統一のため現状維持

## 関連 Issue

closes #17