### PR TITLE
refactor(actions): #29 ActionContext を Result パターンに移行し関心分離を改善

### DIFF
--- a/docs/adr/001-action-result-pattern.md
+++ b/docs/adr/001-action-result-pattern.md
@@ -1,0 +1,175 @@
+# ADR-001: ActionContext を Result パターンに移行し関心分離を改善する
+
+## ステータス
+
+提案中 (Proposed)
+
+## コンテキスト
+
+### 現状の問題
+
+現在の `ActionHandler` は `ActionContext`（5プロパティの God Object）を受け取り、アクション内部で直接 `setAppState` / `startTransition` を呼び出して状態を変更している。
+
+```typescript
+export interface ActionContext {
+  fss: FileSystemService;
+  openImageFile: () => Promise<OpenImageFileResult | null>;
+  themeApi: { theme: 'dark' | 'light'; setTheme: ... };
+  startTransition: (callback: () => void) => void;
+  setAppState: React.Dispatch<React.SetStateAction<AppState>>;
+}
+export type ActionHandler = (context: ActionContext) => Promise<void>;
+```
+
+この設計には以下の問題がある：
+
+1. **過剰な依存**: 各アクションは 5 プロパティ中 2〜3 個しか使わないが、全プロパティにアクセスできてしまう
+   - `openFolderAction`: `fss`, `startTransition`, `setAppState` のみ使用
+   - `toggleThemeAction`: `themeApi` のみ使用
+2. **テストの肥大化**: 全テストで 5 プロパティ全てのモックが必要（`createMockContext` が 15 行）
+3. **関心の混在**: 「何をするか（ビジネスロジック）」と「どう適用するか（React 状態更新）」が同一関数内に混在
+4. **再利用性の欠如**: アクションロジックが React の `setAppState` / `startTransition` に直接依存しているため、別コンテキストでの再利用が困難
+
+### 背景
+
+Issue #29 として改善が要請された。プロジェクトは機能ベースアーキテクチャを採用しており、関心の分離を重視している。
+
+## 決定
+
+**Result パターン** を採用する。各アクションは副作用を直接実行せず、「何が起きたか」を表す `ActionResult`（Discriminated Union）を返す。状態適用は `applyResult` 関数に一元化する。
+
+### 新しい型設計
+
+```typescript
+/** アクション結果の discriminated union */
+export type ActionResult =
+  | { type: 'navigate-folder'; folderPath: string; initialImageIndex: number }
+  | { type: 'set-theme'; theme: 'dark' | 'light' }
+  | { type: 'noop' };
+
+/** 依存が束縛済みのハンドラー */
+export type BoundActionHandler = () => Promise<ActionResult>;
+
+/** アクションが必要とする外部依存 */
+export interface ActionDependencies {
+  fss: FileSystemService;
+  openImageFile: () => Promise<OpenImageFileResult | null>;
+  themeApi: { theme: 'dark' | 'light'; setTheme: (theme: 'dark' | 'light') => void };
+}
+
+/** ActionResult を副作用に変換するための依存 */
+export interface ResultApplier {
+  startTransition: (callback: () => void) => void;
+  setAppState: React.Dispatch<React.SetStateAction<AppState>>;
+  setTheme: (theme: 'dark' | 'light') => void;
+}
+```
+
+### 新しいアクション設計
+
+各アクションは必要最小限の引数のみを受け取る：
+
+```typescript
+// openFolderAction: fss のみ
+export const openFolderAction = async (fss: FileSystemService): Promise<ActionResult> => { ... };
+
+// openImageAction: openImageFile のみ
+export const openImageAction = async (
+  openImageFile: () => Promise<OpenImageFileResult | null>,
+): Promise<ActionResult> => { ... };
+
+// toggleThemeAction: currentTheme のみ
+export const toggleThemeAction = async (currentTheme: 'dark' | 'light'): Promise<ActionResult> => { ... };
+```
+
+### applyResult（副作用適用の一元化）
+
+```typescript
+export function applyResult(result: ActionResult, applier: ResultApplier): void {
+  switch (result.type) {
+    case 'navigate-folder':
+      applier.startTransition(() => {
+        applier.setAppState((prev) => ({
+          ...prev,
+          currentFolderPath: result.folderPath,
+          initialImageIndex: result.initialImageIndex,
+        }));
+      });
+      break;
+    case 'set-theme':
+      applier.setTheme(result.theme);
+      break;
+    case 'noop':
+      break;
+  }
+}
+```
+
+### Registry の変更
+
+`createActionRegistry` が `ActionDependencies` を受け取り、各アクションに必要な依存のみを束縛する：
+
+```typescript
+export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
+  return new Map([
+    ['open-folder', () => openFolderAction(deps.fss)],
+    ['open-image', () => openImageAction(deps.openImageFile)],
+    ['toggle-theme', () => toggleThemeAction(deps.themeApi.theme)],
+  ]);
+}
+```
+
+## 帰結
+
+### メリット
+
+1. **関心の分離**: ビジネスロジック（アクション）と副作用適用（applyResult）が明確に分離
+2. **テスト容易性の向上**: 各アクションのテストでは最小限のモックのみ必要。戻り値をアサートするだけで良い
+3. **型安全性**: Discriminated Union の exhaustive check により、未処理の結果型がコンパイル時に検出可能
+4. **拡張性**: 新しい `ActionResult` バリアントを追加するだけで新しい副作用パターンに対応可能
+5. **依存の最小化**: 各アクションが本当に必要なものだけを受け取るため、不必要な結合がなくなる
+
+### デメリット
+
+1. **既存ユニットテストの全面書き換え**: 16件のユニットテストが影響を受ける（ただし統合テスト 13件は影響なし）
+2. **間接性の増加**: アクション → 結果 → 適用 の2ステップになるため、コードの追跡が1段階増える
+3. **型定義の増加**: `ActionResult`, `BoundActionHandler`, `ActionDependencies`, `ResultApplier` など新規型が4つ追加
+
+### 影響
+
+- `ActionContext` と `ActionHandler` 型は削除される
+- `createMockContext` テストヘルパーは不要になる
+- `app-shell` feature の公開 API（エクスポート型）が変更される
+- App.tsx の `useAppActions` 呼び出しが2引数に変更される
+
+## 代替案
+
+### A. ActionContext を維持し戻り値だけ変更
+
+```typescript
+type ActionHandler = (context: ActionContext) => Promise<ActionResult>;
+```
+
+**却下理由**: 各アクションが依然として全プロパティにアクセス可能。関心分離の目標を達成できない。テストモックの簡略化にも貢献しない。
+
+### B. switch/dispatch パターン（Map-based Registry を廃止）
+
+```typescript
+function dispatch(actionId: AppMenuBarEvent, deps: ActionDependencies): Promise<ActionResult> {
+  switch (actionId) {
+    case 'open-folder': return openFolderAction(deps.fss);
+    // ...
+  }
+}
+```
+
+**却下理由**: 既存の Registry パターンとの一貫性が失われる。Open/Closed 原則に反し、新アクション追加時に switch 分岐を追加する必要がある。Map-based Registry はエントリの追加だけで済む。
+
+### C. noop を null で表現（`ActionResult | null`）
+
+**却下理由**: TypeScript の exhaustive check が使えない。呼び出し側で null チェックが必要になり、`switch` での統一的なハンドリングができない。
+
+## 参考
+
+- Issue #29
+- [docs/frontend-architecture-analysis.md](../frontend-architecture-analysis.md)

--- a/docs/adr/001-action-result-pattern.md
+++ b/docs/adr/001-action-result-pattern.md
@@ -2,13 +2,17 @@
 
 ## ステータス
 
-提案中 (Proposed)
+Accepted
+
+## 日付
+
+2026-03-15
 
 ## コンテキスト
 
 ### 現状の問題
 
-現在の `ActionHandler` は `ActionContext`（5プロパティの God Object）を受け取り、アクション内部で直接 `setAppState` / `startTransition` を呼び出して状態を変更している。
+Issue #17 で導入した Command Registry パターンにおける `ActionHandler` は `ActionContext`（5 プロパティの God Object）を受け取り、アクション内部で直接 `setAppState` / `startTransition` を呼び出して状態を変更していた。
 
 ```typescript
 export interface ActionContext {
@@ -21,43 +25,50 @@ export interface ActionContext {
 export type ActionHandler = (context: ActionContext) => Promise<void>;
 ```
 
-この設計には以下の問題がある：
+この設計には以下の問題があった：
 
-1. **過剰な依存**: 各アクションは 5 プロパティ中 2〜3 個しか使わないが、全プロパティにアクセスできてしまう
+1. **過剰な依存（ISP 違反）**: 各アクションは 5 プロパティ中 1〜3 個しか使わないが、全プロパティにアクセスできる
    - `openFolderAction`: `fss`, `startTransition`, `setAppState` のみ使用
-   - `toggleThemeAction`: `themeApi` のみ使用
+   - `toggleThemeAction`: `themeApi` のみ使用（5 中 1）
 2. **テストの肥大化**: 全テストで 5 プロパティ全てのモックが必要（`createMockContext` が 15 行）
-3. **関心の混在**: 「何をするか（ビジネスロジック）」と「どう適用するか（React 状態更新）」が同一関数内に混在
-4. **再利用性の欠如**: アクションロジックが React の `setAppState` / `startTransition` に直接依存しているため、別コンテキストでの再利用が困難
-
-### 背景
-
-Issue #29 として改善が要請された。プロジェクトは機能ベースアーキテクチャを採用しており、関心の分離を重視している。
+3. **関心の混在**: 「何をするか（ドメインロジック）」と「どう適用するか（React 状態更新）」が同一関数内に混在
+4. **再利用性の欠如**: アクションロジックが React の `setAppState` / `startTransition` に直接依存
+5. **DI 二重化**: 同じ `fss` が ServiceContext と ActionContext の 2 つの経路で注入される
 
 ## 決定
 
-**Result パターン** を採用する。各アクションは副作用を直接実行せず、「何が起きたか」を表す `ActionResult`（Discriminated Union）を返す。状態適用は `applyResult` 関数に一元化する。
+**Result パターン** を採用する。各アクションは副作用を直接実行せず、「何が起きたか」を表す `ActionResult`（Discriminated Union）を返す。キャンセル/何もしない場合は `null` を返す。状態適用は `applyResult` 関数に一元化する。
 
-### 新しい型設計
+### 型設計
 
 ```typescript
-/** アクション結果の discriminated union */
-export type ActionResult =
-  | { type: 'navigate-folder'; folderPath: string; initialImageIndex: number }
-  | { type: 'set-theme'; theme: 'dark' | 'light' }
-  | { type: 'noop' };
+/** フォルダ選択結果（openFolderAction / openImageAction 共通） */
+export interface FolderSelectedResult {
+  type: 'folder-selected';
+  folderPath: string;
+  initialImageIndex: number;
+}
+
+/** テーマ切替結果 */
+export interface ThemeToggledResult {
+  type: 'theme-toggled';
+  theme: 'dark' | 'light';
+}
+
+/** 全結果の discriminated union。キャンセル時は null。 */
+export type ActionResult = FolderSelectedResult | ThemeToggledResult;
 
 /** 依存が束縛済みのハンドラー */
-export type BoundActionHandler = () => Promise<ActionResult>;
+export type BoundActionHandler = () => Promise<ActionResult | null>;
 
-/** アクションが必要とする外部依存 */
+/** アクションの計算に必要な外部依存（読み取り側） */
 export interface ActionDependencies {
   fss: FileSystemService;
   openImageFile: () => Promise<OpenImageFileResult | null>;
-  themeApi: { theme: 'dark' | 'light'; setTheme: (theme: 'dark' | 'light') => void };
+  currentTheme: 'dark' | 'light';
 }
 
-/** ActionResult を副作用に変換するための依存 */
+/** ActionResult を副作用に変換するための依存（書き込み側） */
 export interface ResultApplier {
   startTransition: (callback: () => void) => void;
   setAppState: React.Dispatch<React.SetStateAction<AppState>>;
@@ -65,29 +76,38 @@ export interface ResultApplier {
 }
 ```
 
-### 新しいアクション設計
+### アクション設計
 
-各アクションは必要最小限の引数のみを受け取る：
+各アクションは必要最小限の引数のみを受け取り、結果データを返す純粋関数：
 
 ```typescript
 // openFolderAction: fss のみ
-export const openFolderAction = async (fss: FileSystemService): Promise<ActionResult> => { ... };
+export const openFolderAction = async (
+  fss: FileSystemService,
+): Promise<FolderSelectedResult | null> => { ... };
 
 // openImageAction: openImageFile のみ
 export const openImageAction = async (
   openImageFile: () => Promise<OpenImageFileResult | null>,
-): Promise<ActionResult> => { ... };
+): Promise<FolderSelectedResult | null> => { ... };
 
-// toggleThemeAction: currentTheme のみ
-export const toggleThemeAction = async (currentTheme: 'dark' | 'light'): Promise<ActionResult> => { ... };
+// toggleThemeAction: currentTheme のみ（同期関数）
+export const toggleThemeAction = (
+  currentTheme: 'dark' | 'light',
+): ThemeToggledResult => { ... };
 ```
 
-### applyResult（副作用適用の一元化）
+### 副作用適用の一元化（applyResult）
 
 ```typescript
-export function applyResult(result: ActionResult, applier: ResultApplier): void {
+export function applyResult(
+  result: ActionResult | null,
+  applier: ResultApplier,
+): void {
+  if (result === null) return;
+
   switch (result.type) {
-    case 'navigate-folder':
+    case 'folder-selected':
       applier.startTransition(() => {
         applier.setAppState((prev) => ({
           ...prev,
@@ -96,27 +116,29 @@ export function applyResult(result: ActionResult, applier: ResultApplier): void 
         }));
       });
       break;
-    case 'set-theme':
+    case 'theme-toggled':
       applier.setTheme(result.theme);
-      break;
-    case 'noop':
       break;
   }
 }
 ```
 
-### Registry の変更
+### 依存の分離
 
-`createActionRegistry` が `ActionDependencies` を受け取り、各アクションに必要な依存のみを束縛する：
-
-```typescript
-export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
-  return new Map([
-    ['open-folder', () => openFolderAction(deps.fss)],
-    ['open-image', () => openImageAction(deps.openImageFile)],
-    ['toggle-theme', () => toggleThemeAction(deps.themeApi.theme)],
-  ]);
-}
+```
+App.tsx
+  ├── ActionDependencies（読み取り側）
+  │     fss ──────────────→ openFolderAction(fss)
+  │     openImageFile ────→ openImageAction(openImageFile)
+  │     currentTheme ─────→ toggleThemeAction(currentTheme)
+  │
+  │     ↓ BoundActionHandler()
+  │     ↓ ActionResult | null
+  │
+  └── ResultApplier（書き込み側）
+        startTransition ──→ folder-selected の適用
+        setAppState ──────→ folder-selected の適用
+        setTheme ─────────→ theme-toggled の適用
 ```
 
 ## 帰結
@@ -124,23 +146,41 @@ export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
 ### メリット
 
 1. **関心の分離**: ビジネスロジック（アクション）と副作用適用（applyResult）が明確に分離
-2. **テスト容易性の向上**: 各アクションのテストでは最小限のモックのみ必要。戻り値をアサートするだけで良い
-3. **型安全性**: Discriminated Union の exhaustive check により、未処理の結果型がコンパイル時に検出可能
-4. **拡張性**: 新しい `ActionResult` バリアントを追加するだけで新しい副作用パターンに対応可能
-5. **依存の最小化**: 各アクションが本当に必要なものだけを受け取るため、不必要な結合がなくなる
+2. **テスト容易性の大幅な向上**: 各アクションのテストは最小限のモックで戻り値をアサートするだけ。`openFolderAction` のテストでは `FileSystemService` のモックのみ（5→1 依存）
+3. **型安全性**: Discriminated Union の exhaustive check により未処理の結果型がコンパイル時に検出
+4. **依存の最小化**: `toggleThemeAction` は `'dark' | 'light'` のプリミティブ値のみ。副作用関数にアクセス不可
+5. **純粋関数化**: `toggleThemeAction` は完全に同期的な純粋関数。テスト・理解が最も容易
+6. **Zustand 移行への準備**: Issue #20 の Zustand 移行時に `applyResult` のみ書き換えれば済む
 
 ### デメリット
 
-1. **既存ユニットテストの全面書き換え**: 16件のユニットテストが影響を受ける（ただし統合テスト 13件は影響なし）
-2. **間接性の増加**: アクション → 結果 → 適用 の2ステップになるため、コードの追跡が1段階増える
-3. **型定義の増加**: `ActionResult`, `BoundActionHandler`, `ActionDependencies`, `ResultApplier` など新規型が4つ追加
+1. **既存ユニットテストの全面書き換え**: 16 件のユニットテストが書き換え対象（ただし統合テスト 13 件は影響なし）
+2. **間接性の増加**: アクション → 結果 → 適用の 2 ステップになりコード追跡が 1 段階増加
+3. **型定義の増加**: 新規型が 6 つ追加（`FolderSelectedResult`, `ThemeToggledResult`, `ActionResult`, `BoundActionHandler`, `ActionDependencies`, `ResultApplier`）
 
-### 影響
+### 影響ファイル
 
-- `ActionContext` と `ActionHandler` 型は削除される
-- `createMockContext` テストヘルパーは不要になる
-- `app-shell` feature の公開 API（エクスポート型）が変更される
-- App.tsx の `useAppActions` 呼び出しが2引数に変更される
+| ファイル | 変更内容 |
+|---|---|
+| `actions/types.ts` | 新型追加、旧型（ActionContext, ActionHandler）削除 |
+| `actions/openFolderAction.ts` | `(ctx) → void` → `(fss) → FolderSelectedResult \| null` |
+| `actions/openImageAction.ts` | `(ctx) → void` → `(fn) → FolderSelectedResult \| null` |
+| `actions/toggleThemeAction.ts` | `(ctx) → void` → `(theme) → ThemeToggledResult`（同期化） |
+| `actions/actionRegistry.ts` | `createActionRegistry(deps)` に変更 |
+| `hooks/useAppActions.ts` | 2 引数化 + `applyResult` 追加 |
+| `actions/index.ts` | エクスポート更新 |
+| `App.tsx` | `useAppActions` 呼び出し変更 |
+| `__tests__/helpers.ts` | `createMockContext` → `createMockDeps` + `createMockApplier` |
+
+## 設計判断
+
+| 決定事項 | 却下した選択肢 | 理由 |
+|---|---|---|
+| キャンセル = `null` | `{ type: 'noop' }` バリアント | null ガードが 1 行で完結。switch の exhaustive check は非 null の ActionResult に対して有効。noop は冗長 |
+| `FolderSelectedResult` 共有 | アクションごとに別型 | 同一の副作用（フォルダ遷移 + インデックス設定）のため DRY |
+| `currentTheme` プリミティブ | `themeApi` オブジェクト全体 | 読み取りに必要なのは値のみ。setTheme へのアクセスを遮断 |
+| `toggleThemeAction` 同期化 | async のまま維持 | 非同期処理なし。Registry の async ラッパーで BoundActionHandler に適合 |
+| `applyResult` を useAppActions.ts 内配置 | 別ファイル | 密結合だがファイル数を増やさない。テスト用に個別エクスポート |
 
 ## 代替案
 
@@ -150,26 +190,22 @@ export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
 type ActionHandler = (context: ActionContext) => Promise<ActionResult>;
 ```
 
-**却下理由**: 各アクションが依然として全プロパティにアクセス可能。関心分離の目標を達成できない。テストモックの簡略化にも貢献しない。
+**却下理由**: 各アクションが依然として全プロパティにアクセス可能。ISP 違反が残存。テストモックの簡略化にも貢献しない。
 
 ### B. switch/dispatch パターン（Map-based Registry を廃止）
 
+**却下理由**: 既存の Registry パターンとの一貫性が失われる。Open/Closed 原則に反し、新アクション追加時に switch 分岐の追加が必要。
+
+### C. noop バリアントで表現
+
 ```typescript
-function dispatch(actionId: AppMenuBarEvent, deps: ActionDependencies): Promise<ActionResult> {
-  switch (actionId) {
-    case 'open-folder': return openFolderAction(deps.fss);
-    // ...
-  }
-}
+export type ActionResult = ... | { type: 'noop' };
 ```
 
-**却下理由**: 既存の Registry パターンとの一貫性が失われる。Open/Closed 原則に反し、新アクション追加時に switch 分岐を追加する必要がある。Map-based Registry はエントリの追加だけで済む。
-
-### C. noop を null で表現（`ActionResult | null`）
-
-**却下理由**: TypeScript の exhaustive check が使えない。呼び出し側で null チェックが必要になり、`switch` での統一的なハンドリングができない。
+**却下理由**: `null` は「何も起きなかった」のセマンティクスとして最も自然。`applyResult` 内で `case 'noop': break;` を書く必要がある。null ガードは 1 行で完結し、switch の exhaustive check は非 null の ActionResult に対して引き続き有効。
 
 ## 参考
 
-- Issue #29
-- [docs/frontend-architecture-analysis.md](../frontend-architecture-analysis.md)
+- Issue #29 — 本 ADR の起点
+- Issue #17 — Command Registry パターン導入
+- Issue #20 — Zustand 移行（applyResult のみ書き換え対象）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,13 +56,18 @@ function App({ initialState }: { initialState?: Partial<AppState> }) {
   const { openImageFile } = useOpenImageFile(fss);
 
   // Command Registry パターンによるメニューアクション処理
-  const { executeAction } = useAppActions({
-    fss,
-    openImageFile,
-    themeApi,
-    startTransition,
-    setAppState,
-  });
+  const { executeAction } = useAppActions(
+    {
+      fss,
+      openImageFile,
+      currentTheme: themeApi.theme,
+    },
+    {
+      startTransition,
+      setAppState,
+      setTheme: themeApi.setTheme,
+    },
+  );
 
   const handleMenuAction = executeAction;
 

--- a/src/features/app-shell/__tests__/helpers.ts
+++ b/src/features/app-shell/__tests__/helpers.ts
@@ -1,31 +1,5 @@
 import { vi } from 'vitest';
-import type {
-  ActionContext,
-  ActionDependencies,
-  ResultApplier,
-} from '../actions/types';
-
-export function createMockContext(
-  overrides?: Partial<ActionContext>,
-): ActionContext {
-  return {
-    fss: {
-      openDirectoryDialog: vi.fn().mockResolvedValue(null),
-      getBaseName: vi.fn(),
-      getDirName: vi.fn(),
-      listImagesInFolder: vi.fn(),
-      getSiblingFolders: vi.fn(),
-      convertFileSrc: vi.fn(),
-      getFolderThumbnail: vi.fn().mockResolvedValue(null),
-      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
-    },
-    openImageFile: vi.fn().mockResolvedValue(null),
-    themeApi: { theme: 'dark', setTheme: vi.fn() },
-    startTransition: vi.fn((cb: () => void) => cb()),
-    setAppState: vi.fn(),
-    ...overrides,
-  };
-}
+import type { ActionDependencies, ResultApplier } from '../actions/types';
 
 export function createMockDeps(
   overrides?: Partial<ActionDependencies>,

--- a/src/features/app-shell/__tests__/helpers.ts
+++ b/src/features/app-shell/__tests__/helpers.ts
@@ -1,5 +1,9 @@
 import { vi } from 'vitest';
-import type { ActionContext } from '../actions/types';
+import type {
+  ActionContext,
+  ActionDependencies,
+  ResultApplier,
+} from '../actions/types';
 
 export function createMockContext(
   overrides?: Partial<ActionContext>,
@@ -19,6 +23,37 @@ export function createMockContext(
     themeApi: { theme: 'dark', setTheme: vi.fn() },
     startTransition: vi.fn((cb: () => void) => cb()),
     setAppState: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockDeps(
+  overrides?: Partial<ActionDependencies>,
+): ActionDependencies {
+  return {
+    fss: {
+      openDirectoryDialog: vi.fn().mockResolvedValue(null),
+      getBaseName: vi.fn(),
+      getDirName: vi.fn(),
+      listImagesInFolder: vi.fn(),
+      getSiblingFolders: vi.fn(),
+      convertFileSrc: vi.fn(),
+      getFolderThumbnail: vi.fn().mockResolvedValue(null),
+      prefetchFolderThumbnails: vi.fn().mockResolvedValue(undefined),
+    },
+    openImageFile: vi.fn().mockResolvedValue(null),
+    currentTheme: 'dark',
+    ...overrides,
+  };
+}
+
+export function createMockApplier(
+  overrides?: Partial<ResultApplier>,
+): ResultApplier {
+  return {
+    startTransition: vi.fn((cb: () => void) => cb()),
+    setAppState: vi.fn(),
+    setTheme: vi.fn(),
     ...overrides,
   };
 }

--- a/src/features/app-shell/actions/__tests__/actionRegistry.test.ts
+++ b/src/features/app-shell/actions/__tests__/actionRegistry.test.ts
@@ -1,31 +1,67 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockDeps } from '../../__tests__/helpers';
 import { createActionRegistry } from '../actionRegistry';
-import { openFolderAction } from '../openFolderAction';
-import { openImageAction } from '../openImageAction';
-import { toggleThemeAction } from '../toggleThemeAction';
 
 describe('createActionRegistry', () => {
-  it('registers 3 actions', () => {
-    const registry = createActionRegistry();
+  it('3つのアクションが登録される', () => {
+    const deps = createMockDeps();
+    const registry = createActionRegistry(deps);
 
     expect(registry.size).toBe(3);
   });
 
-  it('maps open-folder to openFolderAction', () => {
-    const registry = createActionRegistry();
+  it('open-folder / open-image / toggle-theme のキーが存在する', () => {
+    const deps = createMockDeps();
+    const registry = createActionRegistry(deps);
 
-    expect(registry.get('open-folder')).toBe(openFolderAction);
+    expect(registry.has('open-folder')).toBe(true);
+    expect(registry.has('open-image')).toBe(true);
+    expect(registry.has('toggle-theme')).toBe(true);
   });
 
-  it('maps open-image to openImageAction', () => {
-    const registry = createActionRegistry();
+  it('各ハンドラーは BoundActionHandler（引数なし関数）である', () => {
+    const deps = createMockDeps();
+    const registry = createActionRegistry(deps);
 
-    expect(registry.get('open-image')).toBe(openImageAction);
+    for (const handler of registry.values()) {
+      expect(typeof handler).toBe('function');
+      expect(handler.length).toBe(0);
+    }
   });
 
-  it('maps toggle-theme to toggleThemeAction', () => {
-    const registry = createActionRegistry();
+  it('open-folder ハンドラーが fss.openDirectoryDialog を呼ぶ', async () => {
+    const deps = createMockDeps();
+    vi.mocked(deps.fss.openDirectoryDialog).mockResolvedValue('/test');
 
-    expect(registry.get('toggle-theme')).toBe(toggleThemeAction);
+    const registry = createActionRegistry(deps);
+    const result = await registry.get('open-folder')!();
+
+    expect(deps.fss.openDirectoryDialog).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      type: 'folder-selected',
+      folderPath: '/test',
+      initialImageIndex: 0,
+    });
+  });
+
+  it('toggle-theme ハンドラーが currentTheme に基づいて結果を返す', async () => {
+    const deps = createMockDeps({ currentTheme: 'light' });
+
+    const registry = createActionRegistry(deps);
+    const result = await registry.get('toggle-theme')!();
+
+    expect(result).toEqual({
+      type: 'theme-toggled',
+      theme: 'dark',
+    });
+  });
+
+  it('キャンセル時: ハンドラーが null を返す', async () => {
+    const deps = createMockDeps();
+
+    const registry = createActionRegistry(deps);
+    const result = await registry.get('open-folder')!();
+
+    expect(result).toBeNull();
   });
 });

--- a/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
@@ -1,49 +1,41 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockContext } from '../../__tests__/helpers';
+import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
+import { describe, expect, it, vi } from 'vitest';
 import { openFolderAction } from '../openFolderAction';
-import type { ActionContext } from '../types';
+
+function createMockFss(
+  dialogResult: string | null = null,
+): FileSystemService {
+  return {
+    openDirectoryDialog: vi.fn().mockResolvedValue(dialogResult),
+  } as unknown as FileSystemService;
+}
 
 describe('openFolderAction', () => {
-  let ctx: ActionContext;
+  it('フォルダ選択成功時: FolderSelectedResult を返す', async () => {
+    const fss = createMockFss('/some/folder');
 
-  beforeEach(() => {
-    ctx = createMockContext();
+    const result = await openFolderAction(fss);
+
+    expect(result).toEqual({
+      type: 'folder-selected',
+      folderPath: '/some/folder',
+      initialImageIndex: 0,
+    });
   });
 
-  it('calls setAppState via startTransition when dialog returns a path', async () => {
-    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/some/folder');
+  it('フォルダ選択成功時: initialImageIndex は常に 0', async () => {
+    const fss = createMockFss('/another/folder');
 
-    await openFolderAction(ctx);
+    const result = await openFolderAction(fss);
 
-    expect(ctx.startTransition).toHaveBeenCalledOnce();
-    expect(ctx.setAppState).toHaveBeenCalledOnce();
+    expect(result?.initialImageIndex).toBe(0);
   });
 
-  it('sets currentFolderPath and initialImageIndex: 0', async () => {
-    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/some/folder');
+  it('キャンセル時（null）: null を返す', async () => {
+    const fss = createMockFss(null);
 
-    await openFolderAction(ctx);
+    const result = await openFolderAction(fss);
 
-    const updater = vi.mocked(ctx.setAppState).mock.calls[0][0];
-    // updater is a callback; invoke it with a dummy prev state
-    const prev = { currentFolderPath: '', initialImageIndex: 5 };
-    const next =
-      typeof updater === 'function' ? updater(prev as never) : updater;
-
-    expect(next).toEqual(
-      expect.objectContaining({
-        currentFolderPath: '/some/folder',
-        initialImageIndex: 0,
-      }),
-    );
-  });
-
-  it('does not call setAppState when dialog is cancelled (null)', async () => {
-    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue(null);
-
-    await openFolderAction(ctx);
-
-    expect(ctx.setAppState).not.toHaveBeenCalled();
-    expect(ctx.startTransition).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });

--- a/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openFolderAction.test.ts
@@ -1,10 +1,8 @@
-import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
 import { describe, expect, it, vi } from 'vitest';
+import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
 import { openFolderAction } from '../openFolderAction';
 
-function createMockFss(
-  dialogResult: string | null = null,
-): FileSystemService {
+function createMockFss(dialogResult: string | null = null): FileSystemService {
   return {
     openDirectoryDialog: vi.fn().mockResolvedValue(dialogResult),
   } as unknown as FileSystemService;

--- a/src/features/app-shell/actions/__tests__/openImageAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/openImageAction.test.ts
@@ -1,69 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockContext } from '../../__tests__/helpers';
+import { describe, expect, it, vi } from 'vitest';
 import { openImageAction } from '../openImageAction';
-import type { ActionContext } from '../types';
 
 describe('openImageAction', () => {
-  let ctx: ActionContext;
-
-  beforeEach(() => {
-    ctx = createMockContext();
-  });
-
-  it('calls setAppState via startTransition when openImageFile returns a result', async () => {
-    vi.mocked(ctx.openImageFile).mockResolvedValue({
-      folderPath: '/images',
-      filePath: '/images/pic.png',
-      index: 3,
-    });
-
-    await openImageAction(ctx);
-
-    expect(ctx.startTransition).toHaveBeenCalledOnce();
-    expect(ctx.setAppState).toHaveBeenCalledOnce();
-  });
-
-  it('passes folderPath and index from the result to setAppState', async () => {
-    vi.mocked(ctx.openImageFile).mockResolvedValue({
+  it('画像選択成功時: FolderSelectedResult を返す', async () => {
+    const openImageFile = vi.fn().mockResolvedValue({
       folderPath: '/images/photos',
       filePath: '/images/photos/img.jpg',
       index: 7,
     });
 
-    await openImageAction(ctx);
+    const result = await openImageAction(openImageFile);
 
-    const updater = vi.mocked(ctx.setAppState).mock.calls[0][0];
-    const prev = { currentFolderPath: '', initialImageIndex: 0 };
-    const next =
-      typeof updater === 'function' ? updater(prev as never) : updater;
-
-    expect(next).toEqual(
-      expect.objectContaining({
-        currentFolderPath: '/images/photos',
-        initialImageIndex: 7,
-      }),
-    );
+    expect(result).toEqual({
+      type: 'folder-selected',
+      folderPath: '/images/photos',
+      initialImageIndex: 7,
+    });
   });
 
-  it('does not call setAppState when openImageFile returns null', async () => {
-    vi.mocked(ctx.openImageFile).mockResolvedValue(null);
+  it('openImageFile が null を返した場合: null を返す', async () => {
+    const openImageFile = vi.fn().mockResolvedValue(null);
 
-    await openImageAction(ctx);
+    const result = await openImageAction(openImageFile);
 
-    expect(ctx.setAppState).not.toHaveBeenCalled();
-    expect(ctx.startTransition).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
-  it('does not call setAppState when result has falsy folderPath', async () => {
-    vi.mocked(ctx.openImageFile).mockResolvedValue({
+  it('folderPath が空文字の場合: null を返す', async () => {
+    const openImageFile = vi.fn().mockResolvedValue({
       folderPath: '',
       filePath: null,
       index: 0,
     });
 
-    await openImageAction(ctx);
+    const result = await openImageAction(openImageFile);
 
-    expect(ctx.setAppState).not.toHaveBeenCalled();
-    expect(ctx.startTransition).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });

--- a/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
+++ b/src/features/app-shell/actions/__tests__/toggleThemeAction.test.ts
@@ -1,30 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockContext } from '../../__tests__/helpers';
+import { describe, expect, it } from 'vitest';
 import { toggleThemeAction } from '../toggleThemeAction';
-import type { ActionContext } from '../types';
 
 describe('toggleThemeAction', () => {
-  let ctx: ActionContext;
+  it('dark → light: ThemeToggledResult を返す', () => {
+    const result = toggleThemeAction('dark');
 
-  beforeEach(() => {
-    ctx = createMockContext();
-  });
-
-  it('switches from dark to light', async () => {
-    ctx = createMockContext({ themeApi: { theme: 'dark', setTheme: vi.fn() } });
-
-    await toggleThemeAction(ctx);
-
-    expect(ctx.themeApi.setTheme).toHaveBeenCalledWith('light');
-  });
-
-  it('switches from light to dark', async () => {
-    ctx = createMockContext({
-      themeApi: { theme: 'light', setTheme: vi.fn() },
+    expect(result).toEqual({
+      type: 'theme-toggled',
+      theme: 'light',
     });
+  });
 
-    await toggleThemeAction(ctx);
+  it('light → dark: ThemeToggledResult を返す', () => {
+    const result = toggleThemeAction('light');
 
-    expect(ctx.themeApi.setTheme).toHaveBeenCalledWith('dark');
+    expect(result).toEqual({
+      type: 'theme-toggled',
+      theme: 'dark',
+    });
   });
 });

--- a/src/features/app-shell/actions/actionRegistry.ts
+++ b/src/features/app-shell/actions/actionRegistry.ts
@@ -12,6 +12,7 @@ export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
   return new Map<AppMenuBarEvent, BoundActionHandler>([
     ['open-folder', () => openFolderAction(deps.fss)],
     ['open-image', () => openImageAction(deps.openImageFile)],
+    // 同期アクションは async ラッパーで BoundActionHandler の Promise 型に適合させる
     ['toggle-theme', async () => toggleThemeAction(deps.currentTheme)],
   ]);
 }

--- a/src/features/app-shell/actions/actionRegistry.ts
+++ b/src/features/app-shell/actions/actionRegistry.ts
@@ -1,15 +1,17 @@
+import type { AppMenuBarEvent } from '../components/AppMenuBar';
 import { openFolderAction } from './openFolderAction';
 import { openImageAction } from './openImageAction';
 import { toggleThemeAction } from './toggleThemeAction';
-import type { ActionRegistry } from './types';
+import type {
+  ActionDependencies,
+  ActionRegistry,
+  BoundActionHandler,
+} from './types';
 
-/**
- * 全アクションハンドラーを登録する Map を生成。
- */
-export function createActionRegistry(): ActionRegistry {
-  return new Map([
-    ['open-folder', openFolderAction],
-    ['open-image', openImageAction],
-    ['toggle-theme', toggleThemeAction],
+export function createActionRegistry(deps: ActionDependencies): ActionRegistry {
+  return new Map<AppMenuBarEvent, BoundActionHandler>([
+    ['open-folder', () => openFolderAction(deps.fss)],
+    ['open-image', () => openImageAction(deps.openImageFile)],
+    ['toggle-theme', async () => toggleThemeAction(deps.currentTheme)],
   ]);
 }

--- a/src/features/app-shell/actions/index.ts
+++ b/src/features/app-shell/actions/index.ts
@@ -1,2 +1,13 @@
 export { createActionRegistry } from './actionRegistry';
-export type { ActionContext, ActionHandler, ActionRegistry } from './types';
+export { openFolderAction } from './openFolderAction';
+export { openImageAction } from './openImageAction';
+export { toggleThemeAction } from './toggleThemeAction';
+export type {
+  ActionDependencies,
+  ActionRegistry,
+  ActionResult,
+  BoundActionHandler,
+  FolderSelectedResult,
+  ResultApplier,
+  ThemeToggledResult,
+} from './types';

--- a/src/features/app-shell/actions/openFolderAction.ts
+++ b/src/features/app-shell/actions/openFolderAction.ts
@@ -1,14 +1,14 @@
-import type { ActionHandler } from './types';
+import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
+import type { FolderSelectedResult } from './types';
 
-export const openFolderAction: ActionHandler = async (ctx) => {
-  const folderPath = await ctx.fss.openDirectoryDialog();
-  if (folderPath) {
-    ctx.startTransition(() => {
-      ctx.setAppState((prev) => ({
-        ...prev,
-        currentFolderPath: folderPath,
-        initialImageIndex: 0,
-      }));
-    });
-  }
+export const openFolderAction = async (
+  fss: FileSystemService,
+): Promise<FolderSelectedResult | null> => {
+  const folderPath = await fss.openDirectoryDialog();
+  if (!folderPath) return null;
+  return {
+    type: 'folder-selected',
+    folderPath,
+    initialImageIndex: 0,
+  };
 };

--- a/src/features/app-shell/actions/openImageAction.ts
+++ b/src/features/app-shell/actions/openImageAction.ts
@@ -1,15 +1,14 @@
-import type { ActionHandler } from './types';
+import type { OpenImageFileResult } from '@/features/folder-navigation/hooks/useOpenImageFile';
+import type { FolderSelectedResult } from './types';
 
-export const openImageAction: ActionHandler = async (ctx) => {
-  const result = await ctx.openImageFile();
-  const folderPath = result?.folderPath;
-  if (folderPath) {
-    ctx.startTransition(() => {
-      ctx.setAppState((prev) => ({
-        ...prev,
-        currentFolderPath: folderPath,
-        initialImageIndex: result.index,
-      }));
-    });
-  }
+export const openImageAction = async (
+  openImageFile: () => Promise<OpenImageFileResult | null>,
+): Promise<FolderSelectedResult | null> => {
+  const result = await openImageFile();
+  if (!result?.folderPath) return null;
+  return {
+    type: 'folder-selected',
+    folderPath: result.folderPath,
+    initialImageIndex: result.index,
+  };
 };

--- a/src/features/app-shell/actions/toggleThemeAction.ts
+++ b/src/features/app-shell/actions/toggleThemeAction.ts
@@ -1,7 +1,10 @@
-import type { ActionHandler } from './types';
+import type { ThemeToggledResult } from './types';
 
-export const toggleThemeAction: ActionHandler = async (ctx) => {
-  const { theme: currentTheme, setTheme } = ctx.themeApi;
-  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
-  setTheme(nextTheme);
+export const toggleThemeAction = (
+  currentTheme: 'dark' | 'light',
+): ThemeToggledResult => {
+  return {
+    type: 'theme-toggled',
+    theme: currentTheme === 'dark' ? 'light' : 'dark',
+  };
 };

--- a/src/features/app-shell/actions/types.ts
+++ b/src/features/app-shell/actions/types.ts
@@ -43,26 +43,3 @@ export interface ResultApplier {
   setAppState: React.Dispatch<React.SetStateAction<AppState>>;
   setTheme: (theme: 'dark' | 'light') => void;
 }
-
-// ============================================================
-// 旧型（Phase 3 で削除予定）
-// ============================================================
-
-/**
- * @deprecated Result パターン移行後に削除予定。ActionDependencies + ResultApplier に分割された。
- */
-export interface ActionContext {
-  fss: FileSystemService;
-  openImageFile: () => Promise<OpenImageFileResult | null>;
-  themeApi: {
-    theme: 'dark' | 'light';
-    setTheme: (theme: 'dark' | 'light') => void;
-  };
-  startTransition: (callback: () => void) => void;
-  setAppState: React.Dispatch<React.SetStateAction<AppState>>;
-}
-
-/**
- * @deprecated Result パターン移行後に削除予定。BoundActionHandler に置換された。
- */
-export type ActionHandler = (context: ActionContext) => Promise<void>;

--- a/src/features/app-shell/actions/types.ts
+++ b/src/features/app-shell/actions/types.ts
@@ -3,9 +3,53 @@ import type { OpenImageFileResult } from '@/features/folder-navigation/hooks/use
 import type { FileSystemService } from '@/features/folder-navigation/services/FileSystemService';
 import type { AppMenuBarEvent } from '../components/AppMenuBar';
 
+// ============================================================
+// Result 型（discriminated union）
+// ============================================================
+
+export interface FolderSelectedResult {
+  type: 'folder-selected';
+  folderPath: string;
+  initialImageIndex: number;
+}
+
+export interface ThemeToggledResult {
+  type: 'theme-toggled';
+  theme: 'dark' | 'light';
+}
+
+export type ActionResult = FolderSelectedResult | ThemeToggledResult;
+
+// ============================================================
+// Handler 型
+// ============================================================
+
+export type BoundActionHandler = () => Promise<ActionResult | null>;
+
+export type ActionRegistry = Map<AppMenuBarEvent, BoundActionHandler>;
+
+// ============================================================
+// 依存型
+// ============================================================
+
+export interface ActionDependencies {
+  fss: FileSystemService;
+  openImageFile: () => Promise<OpenImageFileResult | null>;
+  currentTheme: 'dark' | 'light';
+}
+
+export interface ResultApplier {
+  startTransition: (callback: () => void) => void;
+  setAppState: React.Dispatch<React.SetStateAction<AppState>>;
+  setTheme: (theme: 'dark' | 'light') => void;
+}
+
+// ============================================================
+// 旧型（Phase 3 で削除予定）
+// ============================================================
+
 /**
- * アクションハンドラーが受け取るコンテキスト。
- * App コンポーネントが持つ依存を集約したもの。
+ * @deprecated Result パターン移行後に削除予定。ActionDependencies + ResultApplier に分割された。
  */
 export interface ActionContext {
   fss: FileSystemService;
@@ -19,11 +63,6 @@ export interface ActionContext {
 }
 
 /**
- * 個別アクションハンドラーの型。
+ * @deprecated Result パターン移行後に削除予定。BoundActionHandler に置換された。
  */
 export type ActionHandler = (context: ActionContext) => Promise<void>;
-
-/**
- * アクション ID → ハンドラー関数の Map 型。
- */
-export type ActionRegistry = Map<AppMenuBarEvent, ActionHandler>;

--- a/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
+++ b/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
@@ -1,9 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  createMockApplier,
-  createMockDeps,
-} from '../../__tests__/helpers';
+import { createMockApplier, createMockDeps } from '../../__tests__/helpers';
 import type { ActionDependencies, ResultApplier } from '../../actions/types';
 import { applyResult, useAppActions } from '../useAppActions';
 
@@ -129,9 +126,7 @@ describe('useAppActions', () => {
     const error = new Error('boom');
     vi.mocked(deps.fss.openDirectoryDialog).mockRejectedValue(error);
 
-    const errorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { result } = renderHook(() => useAppActions(deps, applier));
     await result.current.executeAction('open-folder');

--- a/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
+++ b/src/features/app-shell/hooks/__tests__/useAppActions.test.ts
@@ -1,46 +1,139 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMockContext } from '../../__tests__/helpers';
-import type { ActionContext } from '../../actions/types';
-import { useAppActions } from '../useAppActions';
+import {
+  createMockApplier,
+  createMockDeps,
+} from '../../__tests__/helpers';
+import type { ActionDependencies, ResultApplier } from '../../actions/types';
+import { applyResult, useAppActions } from '../useAppActions';
 
-describe('useAppActions', () => {
-  let ctx: ActionContext;
+describe('applyResult', () => {
+  let applier: ResultApplier;
 
   beforeEach(() => {
-    ctx = createMockContext();
+    applier = createMockApplier();
   });
 
-  it('executeAction invokes the registered handler', async () => {
-    vi.mocked(ctx.fss.openDirectoryDialog).mockResolvedValue('/test');
+  it('folder-selected: startTransition 内で setAppState を呼び出す', () => {
+    applyResult(
+      {
+        type: 'folder-selected',
+        folderPath: '/test/folder',
+        initialImageIndex: 5,
+      },
+      applier,
+    );
 
-    const { result } = renderHook(() => useAppActions(ctx));
+    expect(applier.startTransition).toHaveBeenCalledOnce();
+    expect(applier.setAppState).toHaveBeenCalledOnce();
+  });
+
+  it('folder-selected: setAppState の updater が正しい状態を生成する', () => {
+    applyResult(
+      {
+        type: 'folder-selected',
+        folderPath: '/new/path',
+        initialImageIndex: 3,
+      },
+      applier,
+    );
+
+    const updater = vi.mocked(applier.setAppState).mock.calls[0][0];
+    const prev = { currentFolderPath: '/old/path', initialImageIndex: 0 };
+    const next =
+      typeof updater === 'function' ? updater(prev as never) : updater;
+
+    expect(next).toEqual(
+      expect.objectContaining({
+        currentFolderPath: '/new/path',
+        initialImageIndex: 3,
+      }),
+    );
+  });
+
+  it('theme-toggled: setTheme を呼び出す', () => {
+    applyResult({ type: 'theme-toggled', theme: 'light' }, applier);
+
+    expect(applier.setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('theme-toggled: setAppState / startTransition を呼ばない', () => {
+    applyResult({ type: 'theme-toggled', theme: 'dark' }, applier);
+
+    expect(applier.setAppState).not.toHaveBeenCalled();
+    expect(applier.startTransition).not.toHaveBeenCalled();
+  });
+
+  it('null: 副作用を一切実行しない', () => {
+    applyResult(null, applier);
+
+    expect(applier.startTransition).not.toHaveBeenCalled();
+    expect(applier.setAppState).not.toHaveBeenCalled();
+    expect(applier.setTheme).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAppActions', () => {
+  let deps: ActionDependencies;
+  let applier: ResultApplier;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    applier = createMockApplier();
+  });
+
+  it('open-folder 実行: ハンドラーの結果を applyResult で適用する', async () => {
+    vi.mocked(deps.fss.openDirectoryDialog).mockResolvedValue('/test');
+
+    const { result } = renderHook(() => useAppActions(deps, applier));
 
     await result.current.executeAction('open-folder');
 
-    expect(ctx.fss.openDirectoryDialog).toHaveBeenCalledOnce();
-    expect(ctx.setAppState).toHaveBeenCalledOnce();
+    expect(deps.fss.openDirectoryDialog).toHaveBeenCalledOnce();
+    expect(applier.startTransition).toHaveBeenCalledOnce();
+    expect(applier.setAppState).toHaveBeenCalledOnce();
   });
 
-  it('warns on unregistered action id', async () => {
+  it('open-folder キャンセル: 副作用が実行されない', async () => {
+    vi.mocked(deps.fss.openDirectoryDialog).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAppActions(deps, applier));
+
+    await result.current.executeAction('open-folder');
+
+    expect(applier.setAppState).not.toHaveBeenCalled();
+  });
+
+  it('toggle-theme 実行: setTheme が呼ばれる', async () => {
+    deps = createMockDeps({ currentTheme: 'dark' });
+
+    const { result } = renderHook(() => useAppActions(deps, applier));
+
+    await result.current.executeAction('toggle-theme');
+
+    expect(applier.setTheme).toHaveBeenCalledWith('light');
+  });
+
+  it('未登録のアクション ID: console.warn を出力する', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const { result } = renderHook(() => useAppActions(ctx));
+    const { result } = renderHook(() => useAppActions(deps, applier));
 
-    // 'exit' is a valid AppMenuBarEvent but not registered in the registry
     await result.current.executeAction('exit');
 
     expect(warnSpy).toHaveBeenCalledWith('Unhandled menu action: exit');
     warnSpy.mockRestore();
   });
 
-  it('catches handler errors and logs them with console.error', async () => {
+  it('ハンドラーエラー: console.error でログ出力する', async () => {
     const error = new Error('boom');
-    vi.mocked(ctx.fss.openDirectoryDialog).mockRejectedValue(error);
+    vi.mocked(deps.fss.openDirectoryDialog).mockRejectedValue(error);
 
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
-    const { result } = renderHook(() => useAppActions(ctx));
+    const { result } = renderHook(() => useAppActions(deps, applier));
     await result.current.executeAction('open-folder');
 
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/features/app-shell/hooks/useAppActions.ts
+++ b/src/features/app-shell/hooks/useAppActions.ts
@@ -25,6 +25,12 @@ export function applyResult(
     case 'theme-toggled':
       applier.setTheme(result.theme);
       break;
+    default: {
+      const _exhaustive: never = result;
+      throw new Error(
+        `Unhandled result type: ${(_exhaustive as { type: string }).type}`,
+      );
+    }
   }
 }
 

--- a/src/features/app-shell/hooks/useAppActions.ts
+++ b/src/features/app-shell/hooks/useAppActions.ts
@@ -1,14 +1,43 @@
 import { createActionRegistry } from '../actions/actionRegistry';
-import type { ActionContext } from '../actions/types';
+import type {
+  ActionDependencies,
+  ActionResult,
+  ResultApplier,
+} from '../actions/types';
 import type { AppMenuBarEvent } from '../components/AppMenuBar';
 
-const registry = createActionRegistry();
+export function applyResult(
+  result: ActionResult | null,
+  applier: ResultApplier,
+): void {
+  if (result === null) return;
+
+  switch (result.type) {
+    case 'folder-selected':
+      applier.startTransition(() => {
+        applier.setAppState((prev) => ({
+          ...prev,
+          currentFolderPath: result.folderPath,
+          initialImageIndex: result.initialImageIndex,
+        }));
+      });
+      break;
+    case 'theme-toggled':
+      applier.setTheme(result.theme);
+      break;
+  }
+}
 
 interface UseAppActionsReturn {
   executeAction: (actionId: AppMenuBarEvent) => Promise<void>;
 }
 
-export function useAppActions(context: ActionContext): UseAppActionsReturn {
+export function useAppActions(
+  deps: ActionDependencies,
+  applier: ResultApplier,
+): UseAppActionsReturn {
+  const registry = createActionRegistry(deps);
+
   const executeAction = async (actionId: AppMenuBarEvent) => {
     const handler = registry.get(actionId);
     if (!handler) {
@@ -16,7 +45,8 @@ export function useAppActions(context: ActionContext): UseAppActionsReturn {
       return;
     }
     try {
-      await handler(context);
+      const result = await handler();
+      applyResult(result, applier);
     } catch (error) {
       console.error(`Menu action failed [${actionId}]:`, error);
     }

--- a/src/features/app-shell/index.ts
+++ b/src/features/app-shell/index.ts
@@ -1,7 +1,15 @@
 // App Shell Feature Exports
 
 // Actions
-export type { ActionContext, ActionHandler, ActionRegistry } from './actions';
+export type {
+  ActionDependencies,
+  ActionRegistry,
+  ActionResult,
+  BoundActionHandler,
+  FolderSelectedResult,
+  ResultApplier,
+  ThemeToggledResult,
+} from './actions';
 export type {
   AppMenuBarEvent,
   AppMenuBarProps,


### PR DESCRIPTION
## 概要

ActionContext（5プロパティの God Object）を受け取って内部で副作用を実行する ActionHandler パターンから、必要最小限の引数を受け取り `ActionResult | null` を返す純粋関数パターンに移行。副作用適用は `applyResult` 関数に一元化。

## 変更内容

- **型設計**: `ActionResult` discriminated union（`FolderSelectedResult` / `ThemeToggledResult`）、`ActionDependencies`（読み取り側）/ `ResultApplier`（書き込み側）の依存分離
- **openFolderAction**: `(ctx) → void` → `(fss) → FolderSelectedResult | null`（純粋関数化）
- **openImageAction**: `(ctx) → void` → `(openImageFile) → FolderSelectedResult | null`（純粋関数化）
- **toggleThemeAction**: `(ctx) → void` → `(currentTheme) → ThemeToggledResult`（同期純粋関数化）
- **createActionRegistry**: `ActionDependencies` を受け取り必要最小限の依存を束縛
- **useAppActions**: 2引数（`deps`, `applier`）に分離、`applyResult` 関数を追加
- **applyResult**: exhaustive check 付きの switch 文で ActionResult → 副作用変換を一元化
- **App.tsx**: `useAppActions` 呼び出しを新シグネチャに変更
- **旧型削除**: `ActionContext`, `ActionHandler`, `createMockContext` を完全削除
- **ADR-001**: 設計判断を Architecture Decision Record として記録

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（361件）

## TDD サイクル

| Phase | コミット | 内容 |
|-------|---------|------|
| RED | `9b6f138` | 新 Result パターン対応の失敗テスト 19件作成 |
| GREEN | `e4a9811` | 全テストパスする最小限の実装 |
| BLUE | `9f3b968` | 旧型（ActionContext, ActionHandler）とデッドコード削除 |
| ADR | `2c4a5f9` | ADR-001 を実装結果に合わせて更新 |
| Fix | `917e9dd` | レビュー指摘修正 — exhaustive check 追加 |

## レビュー指摘事項

### 🟡 Warning（技術的負債として追跡）

1. **Registry 毎レンダー再生成**: `useAppActions` 内の `createActionRegistry(deps)` が毎レンダーで `new Map` を生成。現在 3 エントリで実害なし。Issue #20（Zustand 移行）時に `useMemo` 化またはストア外部化を検討
2. **未登録イベントの console.warn**: `AppMenuBarEvent` は 20+ バリアントだが Registry には 3 つのみ登録。未登録イベントで `console.warn` が出力される。他の機能でイベント処理を追加する際に再検討

### 🟢 Suggestion（参考情報）

1. `BoundActionHandler` の型を `() => Promise<ActionResult | null> | ActionResult | null` にすることで同期アクションの async ラッパーが不要になる（現時点では over-engineering）
2. `applyResult` の exhaustive check（`default` ブランチ）のランタイムテスト追加（型安全性で十分守られているため優先度低）
3. `AppState` 型を `shared/types/` に移動すると `actions/types.ts → App.tsx` の逆方向依存が解消される（Issue #29 スコープ外、Issue #20 で検討）

## 関連 Issue

closes #29