### PR TITLE
chore(test): #35 Tauriモック定義をmocks.tsに一元化し、テスト基盤を統合

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -12,12 +12,17 @@
 
 ### 1.1 モック定義の重複
 
-| ファイル | 問題 |
-|---------|------|
-| `src/test/setup.ts` | Tauri APIのvi.mock()定義 |
-| `src/test/mocks.ts` | 同じAPIを再度モック（重複） |
+> ✅ **Issue #35 で解消済み**
 
-**影響**: モック設定が分散しており、一貫性を保ちにくい。
+現在の構成:
+
+| ファイル | 役割 |
+|---------|------|
+| `src/test/mocks.ts` | Tauri APIモックの**シングルソースオブトゥルース** |
+| `src/test/setup.ts` | `mocks.ts` の `setupTauriMocks()` を呼び出す形に統合済み |
+
+- `invoke` のデフォルト値は `mockResolvedValue(null)` に統一
+- モック設定は `mocks.ts` に一元化され、一貫性が確保されている
 
 ### 1.2 FileSystemServiceの型とモックの乖離リスク
 
@@ -78,20 +83,19 @@ export interface FileSystemService {
 
 ### 2.2 推奨アプローチ: 最小モック + プリセット
 
+現在の `src/test/mocks.ts` は以下の構成で実装済み:
+
+| エクスポート | 役割 |
+|------------|------|
+| `setupTauriMocks()` | 全 Tauri API モックのセットアップ（`setup.ts` から自動呼び出し） |
+| `resetAllMocks()` | モックリセットユーティリティ |
+| `createMockFileSystemServiceWithThumbnails()` | サムネイル用プリセット（将来用） |
+| `mockStoreInstance` | Store モックインスタンス（export済み、テストから直接参照可能） |
+
+今後、機能別プリセットが必要になった場合は以下のパターンで拡張可能:
+
 ```typescript
-// src/test/mocks.ts に追加
-
-// 最小限のデフォルト実装
-export const createMinimalMock = (): FileSystemService => ({
-  openDirectoryDialog: vi.fn(),
-  getBaseName: vi.fn().mockImplementation((path) => path.split('/').pop() || ''),
-  getDirName: vi.fn().mockImplementation((path) => path.split('/').slice(0, -1).join('/') || '/'),
-  listImagesInFolder: vi.fn().mockResolvedValue([]),
-  getSiblingFolders: vi.fn().mockResolvedValue([]),
-  convertFileSrc: vi.fn((path) => `asset://${path}`),
-});
-
-// 機能別プリセット
+// 機能別プリセットの拡張例
 export const mockPresets = {
   thumbnail: { 
     getOrCreateThumbnail: vi.fn().mockResolvedValue('/cache/thumb.jpg') 
@@ -104,9 +108,6 @@ export const mockPresets = {
     getSiblingFolders: vi.fn().mockResolvedValue(['/folder1', '/folder2']),
   },
 };
-
-// 使用例
-const mockFs = { ...createMinimalMock(), ...mockPresets.thumbnail };
 ```
 
 ### 2.3 実装ステップ
@@ -179,7 +180,7 @@ Issue #33 で以下の問題テストを削除済み:
 | アクション | 詳細 |
 |------------|------|
 | ~~`mocks.test.ts`の修正~~ | ~~モックが実際に動作することを検証するか、削除を検討~~ → Issue #33 で削除済み |
-| モック定義の一元化 | `setup.ts`と`mocks.ts`の重複を解消 |
+| ~~モック定義の一元化~~ | ~~`setup.ts`と`mocks.ts`の重複を解消~~ → ✅ 完了（Issue #35） |
 
 ### 4.2 優先度: 中
 

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,15 +1,20 @@
 import { vi } from 'vitest';
 
+// Default implementations for path utilities - extracted to avoid duplication
+// between initialization and resetAllMocks() re-application
+const convertFileSrcImpl = (path: string) => `asset://${path}`;
+const basenameImpl = (path: string) => path.split('/').pop() || '';
+const dirnameImpl = (path: string) =>
+  path.split('/').slice(0, -1).join('/') || '/';
+
 // Mock function instances at module scope.
 // Vitest hoists variables prefixed with "mock" alongside vi.mock calls,
 // so these can be safely referenced inside vi.mock factory functions.
 const mockInvoke = vi.fn().mockResolvedValue(null);
-const mockConvertFileSrc = vi.fn((path: string) => `asset://${path}`);
+const mockConvertFileSrc = vi.fn().mockImplementation(convertFileSrcImpl);
 const mockDialogOpen = vi.fn().mockResolvedValue(null);
-const mockBasename = vi.fn((path: string) => path.split('/').pop() || '');
-const mockDirname = vi.fn(
-  (path: string) => path.split('/').slice(0, -1).join('/') || '/',
-);
+const mockBasename = vi.fn().mockImplementation(basenameImpl);
+const mockDirname = vi.fn().mockImplementation(dirnameImpl);
 const mockOpenerOpen = vi.fn();
 const mockReadDir = vi.fn().mockResolvedValue([]);
 const mockExists = vi.fn().mockResolvedValue(false);
@@ -77,14 +82,10 @@ export const resetAllMocks = () => {
 
   // Re-apply default implementations after reset
   mockInvoke.mockResolvedValue(null);
-  mockConvertFileSrc.mockImplementation((path: string) => `asset://${path}`);
+  mockConvertFileSrc.mockImplementation(convertFileSrcImpl);
   mockDialogOpen.mockResolvedValue(null);
-  mockBasename.mockImplementation(
-    (path: string) => path.split('/').pop() || '',
-  );
-  mockDirname.mockImplementation(
-    (path: string) => path.split('/').slice(0, -1).join('/') || '/',
-  );
+  mockBasename.mockImplementation(basenameImpl);
+  mockDirname.mockImplementation(dirnameImpl);
   mockReadDir.mockResolvedValue([]);
   mockExists.mockResolvedValue(false);
   mockStoreLoad.mockResolvedValue(mockStoreInstance);

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,5 +1,19 @@
 import { vi } from 'vitest';
 
+// Mock function instances at module scope.
+// Vitest hoists variables prefixed with "mock" alongside vi.mock calls,
+// so these can be safely referenced inside vi.mock factory functions.
+const mockInvoke = vi.fn().mockResolvedValue(null);
+const mockConvertFileSrc = vi.fn((path: string) => `asset://${path}`);
+const mockDialogOpen = vi.fn().mockResolvedValue(null);
+const mockBasename = vi.fn((path: string) => path.split('/').pop() || '');
+const mockDirname = vi.fn(
+  (path: string) => path.split('/').slice(0, -1).join('/') || '/',
+);
+const mockOpenerOpen = vi.fn();
+const mockReadDir = vi.fn().mockResolvedValue([]);
+const mockExists = vi.fn().mockResolvedValue(false);
+
 /**
  * Shared mock store instance - exported for test access
  */
@@ -9,54 +23,74 @@ export const mockStoreInstance = {
   save: vi.fn().mockResolvedValue(undefined),
 };
 
+// Declared after mockStoreInstance to avoid temporal dead zone
+const mockStoreLoad = vi.fn().mockResolvedValue(mockStoreInstance);
+
 /**
  * Setup standardized mocks for Tauri APIs
  */
 export const setupTauriMocks = () => {
   // Mock Tauri core APIs
   vi.mock('@tauri-apps/api/core', () => ({
-    invoke: vi.fn().mockResolvedValue(null),
-    convertFileSrc: vi.fn((path: string) => `asset://${path}`),
+    invoke: mockInvoke,
+    convertFileSrc: mockConvertFileSrc,
   }));
 
   // Mock Tauri dialog plugin
   vi.mock('@tauri-apps/plugin-dialog', () => ({
-    open: vi.fn().mockResolvedValue(null),
+    open: mockDialogOpen,
   }));
 
   // Mock Tauri path utilities
   vi.mock('@tauri-apps/api/path', () => ({
-    basename: vi.fn((path: string) => path.split('/').pop() || ''),
-    dirname: vi.fn(
-      (path: string) => path.split('/').slice(0, -1).join('/') || '/',
-    ),
+    basename: mockBasename,
+    dirname: mockDirname,
   }));
 
   // Mock Tauri opener plugin
   vi.mock('@tauri-apps/plugin-opener', () => ({
-    open: vi.fn(),
+    open: mockOpenerOpen,
   }));
 
   // Mock Tauri filesystem plugin
   vi.mock('@tauri-apps/plugin-fs', () => ({
-    readDir: vi.fn().mockResolvedValue([]),
-    exists: vi.fn().mockResolvedValue(false),
+    readDir: mockReadDir,
+    exists: mockExists,
   }));
 
   // Mock Tauri store plugin
   vi.mock('@tauri-apps/plugin-store', () => ({
     Store: {
-      load: vi.fn().mockResolvedValue(mockStoreInstance),
+      load: mockStoreLoad,
     },
   }));
 };
 
 /**
- * Reset all mocks - useful in beforeEach hooks
+ * Reset all mocks and re-apply default implementations.
+ * Calls vi.resetAllMocks() for a complete reset (including one-time implementations),
+ * then restores the expected default return values so subsequent tests start consistently.
  */
 export const resetAllMocks = () => {
   vi.resetAllMocks();
   vi.clearAllTimers();
+
+  // Re-apply default implementations after reset
+  mockInvoke.mockResolvedValue(null);
+  mockConvertFileSrc.mockImplementation((path: string) => `asset://${path}`);
+  mockDialogOpen.mockResolvedValue(null);
+  mockBasename.mockImplementation(
+    (path: string) => path.split('/').pop() || '',
+  );
+  mockDirname.mockImplementation(
+    (path: string) => path.split('/').slice(0, -1).join('/') || '/',
+  );
+  mockReadDir.mockResolvedValue([]);
+  mockExists.mockResolvedValue(false);
+  mockStoreLoad.mockResolvedValue(mockStoreInstance);
+  mockStoreInstance.get.mockResolvedValue(null);
+  mockStoreInstance.set.mockResolvedValue(undefined);
+  mockStoreInstance.save.mockResolvedValue(undefined);
 };
 
 /**

--- a/src/test/mocks.ts
+++ b/src/test/mocks.ts
@@ -1,18 +1,27 @@
 import { vi } from 'vitest';
 
 /**
+ * Shared mock store instance - exported for test access
+ */
+export const mockStoreInstance = {
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+  save: vi.fn().mockResolvedValue(undefined),
+};
+
+/**
  * Setup standardized mocks for Tauri APIs
  */
 export const setupTauriMocks = () => {
   // Mock Tauri core APIs
   vi.mock('@tauri-apps/api/core', () => ({
-    invoke: vi.fn(),
+    invoke: vi.fn().mockResolvedValue(null),
     convertFileSrc: vi.fn((path: string) => `asset://${path}`),
   }));
 
   // Mock Tauri dialog plugin
   vi.mock('@tauri-apps/plugin-dialog', () => ({
-    open: vi.fn(),
+    open: vi.fn().mockResolvedValue(null),
   }));
 
   // Mock Tauri path utilities
@@ -30,17 +39,11 @@ export const setupTauriMocks = () => {
 
   // Mock Tauri filesystem plugin
   vi.mock('@tauri-apps/plugin-fs', () => ({
-    readDir: vi.fn(),
-    exists: vi.fn(),
+    readDir: vi.fn().mockResolvedValue([]),
+    exists: vi.fn().mockResolvedValue(false),
   }));
 
   // Mock Tauri store plugin
-  const mockStoreInstance = {
-    get: vi.fn().mockResolvedValue(null),
-    set: vi.fn().mockResolvedValue(undefined),
-    save: vi.fn().mockResolvedValue(undefined),
-  };
-
   vi.mock('@tauri-apps/plugin-store', () => ({
     Store: {
       load: vi.fn().mockResolvedValue(mockStoreInstance),

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
+import { setupTauriMocks } from './mocks';
 
 // Setup global vi for tests
 (globalThis as typeof globalThis & { vi: typeof vi }).vi = vi;
@@ -30,43 +31,8 @@ Object.defineProperty(window, 'matchMedia', {
   value: mockMatchMedia,
 });
 
-// Mock Tauri APIs for testing
-const mockTauriCore = {
-  invoke: vi.fn().mockResolvedValue(null),
-};
-
-// Enhanced Tauri Store mock for theme system
-const mockStoreInstance = {
-  get: vi.fn().mockResolvedValue(null),
-  set: vi.fn().mockResolvedValue(undefined),
-  save: vi.fn().mockResolvedValue(undefined),
-};
-
-const mockTauriStore = {
-  Store: {
-    // Mock the static load method
-    load: vi.fn().mockResolvedValue(mockStoreInstance),
-    // Also provide constructor if needed
-    new: vi.fn().mockImplementation(() => mockStoreInstance),
-  },
-  // Export mock instance for direct access in tests
-  __mockStore: mockStoreInstance,
-};
-
-// Mock Tauri modules
-vi.mock('@tauri-apps/api/core', () => mockTauriCore);
-vi.mock('@tauri-apps/plugin-store', () => mockTauriStore);
-
-// Mock Tauri dialog
-vi.mock('@tauri-apps/plugin-dialog', () => ({
-  open: vi.fn().mockResolvedValue(null),
-}));
-
-// Mock Tauri filesystem
-vi.mock('@tauri-apps/plugin-fs', () => ({
-  readDir: vi.fn().mockResolvedValue([]),
-  exists: vi.fn().mockResolvedValue(false),
-}));
+// Setup Tauri API mocks (centralized in mocks.ts)
+setupTauriMocks();
 
 // React 19: Enhanced test utilities
 import { act } from '@testing-library/react';


### PR DESCRIPTION
## 概要

`setup.ts` と `mocks.ts` で重複していた Tauri API モック定義を `mocks.ts` に一元化し、テスト基盤の管理を統合した。

## 変更内容

- `mocks.ts` を Tauri モックのシングルソースオブトゥルースに統合
- `setup.ts` から Tauri モック定義をすべて削除し、`setupTauriMocks()` の呼び出しに置換
- `invoke` のデフォルト値を `mockResolvedValue(null)` に統一
- `mockStoreInstance` を export し、テストから直接参照可能に
- `docs/testing-strategy.md` にモック統合完了を反映

## テスト

- [x] `pnpm type-check` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` PASS（346件）

## レビュー指摘事項

### 🟡 Warning（後続 Issue で対応推奨）

1. **`createMockFileSystemServiceWithThumbnails` が未使用**: 現時点でどのテストからも参照されていない。残す場合は `satisfies FileSystemService` を付与して型安全性を保証する
2. **`mockStoreInstance` のエクスポートが未使用**: 将来必要になった時点でエクスポートする選択肢もある
3. **個別テストでの `setupTauriMocks()` 二重呼び出し**: `setup.ts` でグローバルに呼び出されるにもかかわらず、各テストの `beforeEach` でも再度呼び出されている冗長性がある

### 🟢 Suggestion

1. **`resetAllMocks()` ヘルパーへの統一**: 一部テストが `vi.resetAllMocks()` を直接呼んでおり、タイマークリーンアップの一貫性が保証されない
2. **`testing-strategy.md` セクション 1.3 の FileSystemService 定義が古い**: 現在のインターフェースと乖離がある（Issue #35 スコープ外）

## 関連 Issue

closes #35