### PR TITLE
refactor(test): #52 テストの一時ディレクトリ管理を TempTestDir に統一

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -629,6 +629,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/core_logic/Cargo.toml
+++ b/src-tauri/core_logic/Cargo.toml
@@ -15,3 +15,6 @@ rayon = "1.11"
 blake3 = "1.8"
 thiserror = "2.0"
 num_cpus = "1.16"
+
+[dev-dependencies]
+uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/core_logic/src/fs.rs
+++ b/src-tauri/core_logic/src/fs.rs
@@ -76,24 +76,21 @@ pub fn get_sibling_folders(folder_path: String) -> Result<Vec<String>, CommandEr
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env::temp_dir;
-    use std::fs::{create_dir_all, remove_dir_all, File};
+    use crate::test_helper::test_helpers::TempTestDir;
+    use std::fs::{create_dir_all, File};
 
     #[test]
     fn test_list_images_in_folder_success() {
-        let temp_dir = temp_dir().join("test_list_images_success");
-        create_dir_all(&temp_dir).unwrap();
-        File::create(temp_dir.join("image1.jpg")).unwrap();
-        File::create(temp_dir.join("image2.PNG")).unwrap(); // Uppercase extension
-        File::create(temp_dir.join("document.txt")).unwrap();
+        let temp_dir = TempTestDir::new_random();
+        File::create(temp_dir.path().join("image1.jpg")).unwrap();
+        File::create(temp_dir.path().join("image2.PNG")).unwrap(); // Uppercase extension
+        File::create(temp_dir.path().join("document.txt")).unwrap();
 
-        let images = list_images_in_folder(temp_dir.to_string_lossy().to_string()).unwrap();
+        let images = list_images_in_folder(temp_dir.path().to_string_lossy().to_string()).unwrap();
 
         assert_eq!(images.len(), 2);
         assert!(images.iter().any(|p| p.ends_with("image1.jpg")));
         assert!(images.iter().any(|p| p.ends_with("image2.PNG")));
-
-        remove_dir_all(temp_dir).unwrap();
     }
 
     #[test]
@@ -104,25 +101,22 @@ mod tests {
 
     #[test]
     fn test_get_sibling_folders_success() {
-        let base = temp_dir().join("test_siblings_success");
-        let _ = remove_dir_all(&base);
-        create_dir_all(base.join("A")).unwrap();
-        create_dir_all(base.join("B")).unwrap();
-        create_dir_all(base.join("C")).unwrap();
+        let base = TempTestDir::new_random();
+        create_dir_all(base.path().join("A")).unwrap();
+        create_dir_all(base.path().join("B")).unwrap();
+        create_dir_all(base.path().join("C")).unwrap();
 
-        let current_path = base.join("B").to_string_lossy().to_string();
+        let current_path = base.path().join("B").to_string_lossy().to_string();
         let mut result = get_sibling_folders(current_path).unwrap();
         result.sort(); // Sort for stable assertion
 
         let mut expected = vec![
-            base.join("A").to_string_lossy().to_string(),
-            base.join("C").to_string_lossy().to_string(),
+            base.path().join("A").to_string_lossy().to_string(),
+            base.path().join("C").to_string_lossy().to_string(),
         ];
         expected.sort();
 
         assert_eq!(result, expected);
-
-        remove_dir_all(base).unwrap();
     }
 
     #[test]

--- a/src-tauri/core_logic/src/lib.rs
+++ b/src-tauri/core_logic/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod fs;
+pub mod test_helper;
 pub mod thumbnail;
 
 // 後方互換性のための再エクスポート

--- a/src-tauri/core_logic/src/lib.rs
+++ b/src-tauri/core_logic/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod error;
 pub mod fs;
+#[cfg(test)]
 pub mod test_helper;
 pub mod thumbnail;
 

--- a/src-tauri/core_logic/src/test_helper.rs
+++ b/src-tauri/core_logic/src/test_helper.rs
@@ -23,7 +23,7 @@ pub mod test_helpers {
         }
 
         pub fn path(&self) -> &Path {
-            &self.path
+            self.path.as_path()
         }
     }
 

--- a/src-tauri/core_logic/src/test_helper.rs
+++ b/src-tauri/core_logic/src/test_helper.rs
@@ -7,7 +7,7 @@ pub mod test_helpers {
     };
 
     pub struct TempTestDir {
-        pub path: PathBuf,
+        path: PathBuf,
     }
 
     impl TempTestDir {

--- a/src-tauri/core_logic/src/test_helper.rs
+++ b/src-tauri/core_logic/src/test_helper.rs
@@ -3,7 +3,7 @@ pub mod test_helpers {
     use std::{
         env::temp_dir,
         fs::{create_dir_all, remove_dir_all},
-        path::PathBuf,
+        path::{Path, PathBuf},
     };
 
     pub struct TempTestDir {
@@ -22,7 +22,7 @@ pub mod test_helpers {
             Self::new(&name)
         }
 
-        pub fn path(&self) -> &PathBuf {
+        pub fn path(&self) -> &Path {
             &self.path
         }
     }

--- a/src-tauri/core_logic/src/test_helper.rs
+++ b/src-tauri/core_logic/src/test_helper.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+pub mod test_helpers {
+    use std::{
+        env::temp_dir,
+        fs::{create_dir_all, remove_dir_all},
+        path::PathBuf,
+    };
+
+    pub struct TempTestDir {
+        pub path: PathBuf,
+    }
+
+    impl TempTestDir {
+        pub fn new(name: &str) -> Self {
+            let path = temp_dir().join(name);
+            create_dir_all(&path).unwrap();
+            TempTestDir { path }
+        }
+
+        pub fn new_random() -> Self {
+            let name = uuid::Uuid::new_v4().to_string();
+            Self::new(&name)
+        }
+
+        pub fn path(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+
+    impl Drop for TempTestDir {
+        fn drop(&mut self) {
+            let _ = remove_dir_all(&self.path);
+        }
+    }
+}

--- a/src-tauri/core_logic/src/thumbnail/folder.rs
+++ b/src-tauri/core_logic/src/thumbnail/folder.rs
@@ -39,8 +39,8 @@ pub fn get_first_image_in_folder(folder_path: &str) -> Result<Option<String>, St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env::temp_dir;
-    use std::fs::{create_dir_all, remove_dir_all, File};
+    use crate::test_helper::test_helpers::TempTestDir;
+    use std::fs::File;
 
     // --- FolderThumbnailResult のシリアライゼーションテスト ---
 
@@ -112,39 +112,29 @@ mod tests {
 
     #[test]
     fn test_get_first_image_returns_image_path() {
-        let temp = temp_dir().join("test_folder_thumbnail_first");
-        let _ = remove_dir_all(&temp);
-        create_dir_all(&temp).unwrap();
+        let temp = TempTestDir::new_random();
 
-        // 画像ファイルを作成
-        File::create(temp.join("image1.jpg")).unwrap();
-        File::create(temp.join("image2.png")).unwrap();
+        File::create(temp.path().join("image1.jpg")).unwrap();
+        File::create(temp.path().join("image2.png")).unwrap();
 
-        let result = get_first_image_in_folder(temp.to_str().unwrap());
+        let result = get_first_image_in_folder(temp.path().to_str().unwrap());
         assert!(result.is_ok());
         let first = result.unwrap();
         assert!(first.is_some(), "Should return first image path");
-        // パスに画像拡張子が含まれること
         let path = first.unwrap();
         assert!(
             path.ends_with(".jpg") || path.ends_with(".png"),
             "Should return an image file path, got: {}",
             path
         );
-
-        let _ = remove_dir_all(&temp);
     }
 
     #[test]
     fn test_get_first_image_returns_none_for_empty_folder() {
-        let temp = temp_dir().join("test_folder_thumbnail_empty");
-        let _ = remove_dir_all(&temp);
-        create_dir_all(&temp).unwrap();
+        let temp = TempTestDir::new_random();
 
-        let result = get_first_image_in_folder(temp.to_str().unwrap());
+        let result = get_first_image_in_folder(temp.path().to_str().unwrap());
         assert!(result.is_ok());
         assert!(result.unwrap().is_none(), "Empty folder should return None");
-
-        let _ = remove_dir_all(&temp);
     }
 }

--- a/src-tauri/core_logic/src/thumbnail/generator.rs
+++ b/src-tauri/core_logic/src/thumbnail/generator.rs
@@ -139,25 +139,30 @@ impl ThumbnailGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env::temp_dir;
-    use std::fs::{create_dir_all, remove_dir_all};
+    use crate::test_helper::test_helpers::TempTestDir;
+    use std::fs::create_dir_all;
 
     /// テスト用の ThumbnailGenerator を作成
-    fn create_test_generator() -> ThumbnailGenerator {
-        let cache_dir = temp_dir().join("test_thumbnail_generator_cache");
-        let _ = remove_dir_all(&cache_dir);
+    fn create_test_generator() -> (ThumbnailGenerator, TempTestDir) {
+        let temp = TempTestDir::new_random();
+        let cache_dir = temp.path().join("cache");
         create_dir_all(&cache_dir).unwrap();
-        ThumbnailGenerator::with_default_config(cache_dir).unwrap()
+        let gen = ThumbnailGenerator::with_default_config(cache_dir).unwrap();
+        (gen, temp)
     }
 
     /// テスト用の ThumbnailGenerator（カスタム設定）
     #[allow(dead_code)]
-    fn create_test_generator_with_config(width: u32, height: u32) -> ThumbnailGenerator {
-        let cache_dir = temp_dir().join("test_thumbnail_generator_cache_custom");
-        let _ = remove_dir_all(&cache_dir);
+    fn create_test_generator_with_config(
+        width: u32,
+        height: u32,
+    ) -> (ThumbnailGenerator, TempTestDir) {
+        let temp = TempTestDir::new_random();
+        let cache_dir = temp.path().join("cache");
         create_dir_all(&cache_dir).unwrap();
         let config = ThumbnailConfig::new(width, height, 80, 1024 * 1024 * 1024);
-        ThumbnailGenerator::new(config, cache_dir).unwrap()
+        let gen = ThumbnailGenerator::new(config, cache_dir).unwrap();
+        (gen, temp)
     }
 
     // --- calculate_thumbnail_dimensions テスト ---
@@ -165,10 +170,10 @@ mod tests {
     #[test]
     fn test_calculate_thumbnail_dimensions_landscape() {
         // 横長画像（1920x1080）→ ターゲット200x200
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(1920, 1080);
         assert_eq!(w, 200); // 幅がターゲットに一致
-        assert!(h < 200);   // 高さはターゲット未満（アスペクト比維持）
+        assert!(h < 200); // 高さはターゲット未満（アスペクト比維持）
         assert!(h > 0);
         // 1920/1080 ≈ 1.778、200/1.778 ≈ 112
         assert_eq!(h, 112);
@@ -177,7 +182,7 @@ mod tests {
     #[test]
     fn test_calculate_thumbnail_dimensions_portrait() {
         // 縦長画像（1080x1920）→ ターゲット200x200
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(1080, 1920);
         assert!(w < 200);
         assert_eq!(h, 200); // 高さがターゲットに一致
@@ -189,7 +194,7 @@ mod tests {
     #[test]
     fn test_calculate_thumbnail_dimensions_square() {
         // 正方形画像（500x500）→ ターゲット200x200
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(500, 500);
         // 正方形対正方形ターゲットでは width == height == target
         // aspect_ratio (1.0) == target_aspect_ratio (1.0) → else branch
@@ -200,7 +205,7 @@ mod tests {
     #[test]
     fn test_calculate_thumbnail_dimensions_small_image() {
         // ターゲットより小さい画像（50x50）
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(50, 50);
         // アスペクト比計算は入力サイズに関係なく適用
         assert_eq!(w, 200);
@@ -210,22 +215,22 @@ mod tests {
     #[test]
     fn test_calculate_thumbnail_dimensions_very_wide() {
         // 極端に横長（10000x100）
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(10000, 100);
         assert_eq!(w, 200);
         assert!(h >= 1); // max(1) による下限保証
-        // 10000/100 = 100、200/100 = 2
+                         // 10000/100 = 100、200/100 = 2
         assert_eq!(h, 2);
     }
 
     #[test]
     fn test_calculate_thumbnail_dimensions_very_tall() {
         // 極端に縦長（100x10000）
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let (w, h) = gen.calculate_thumbnail_dimensions(100, 10000);
         assert_eq!(h, 200);
         assert!(w >= 1); // max(1) による下限保証
-        // 100/10000 = 0.01、200*0.01 = 2
+                         // 100/10000 = 0.01、200*0.01 = 2
         assert_eq!(w, 2);
     }
 
@@ -233,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_image_not_found_error() {
-        let gen = create_test_generator();
+        let (gen, _temp) = create_test_generator();
         let result = gen.get_or_create_thumbnail("/nonexistent/path/image.jpg");
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -248,17 +253,14 @@ mod tests {
 
     #[test]
     fn test_generate_thumbnail_success() {
-        // テスト用のJPEG画像を作成
-        let temp = temp_dir().join("test_thumbnail_gen_success");
-        let _ = remove_dir_all(&temp);
-        create_dir_all(&temp).unwrap();
+        let temp = TempTestDir::new_random();
 
-        let image_path = temp.join("test_image.jpg");
-        // 100x100 のテスト画像を生成
+        let image_path = temp.path().join("test_image.jpg");
         let img = image::RgbImage::new(100, 100);
-        img.save_with_format(&image_path, ImageFormat::Jpeg).unwrap();
+        img.save_with_format(&image_path, ImageFormat::Jpeg)
+            .unwrap();
 
-        let cache_dir = temp.join("cache");
+        let cache_dir = temp.path().join("cache");
         create_dir_all(&cache_dir).unwrap();
 
         let gen = ThumbnailGenerator::with_default_config(cache_dir.clone()).unwrap();
@@ -267,31 +269,32 @@ mod tests {
 
         let thumbnail_path = result.unwrap();
         assert!(thumbnail_path.exists(), "Thumbnail file should be created");
-        assert!(thumbnail_path.starts_with(&cache_dir), "Should be in cache dir");
+        assert!(
+            thumbnail_path.starts_with(&cache_dir),
+            "Should be in cache dir"
+        );
         assert!(thumbnail_path.extension().unwrap() == "jpg");
-
-        let _ = remove_dir_all(&temp);
     }
 
     #[test]
     fn test_thumbnail_cache_hit() {
-        // 2回目の呼び出しでキャッシュが使われることを確認
-        let temp = temp_dir().join("test_thumbnail_cache_hit");
-        let _ = remove_dir_all(&temp);
-        create_dir_all(&temp).unwrap();
+        let temp = TempTestDir::new_random();
 
-        let image_path = temp.join("test_cached.jpg");
+        let image_path = temp.path().join("test_cached.jpg");
         let img = image::RgbImage::new(100, 100);
-        img.save_with_format(&image_path, ImageFormat::Jpeg).unwrap();
+        img.save_with_format(&image_path, ImageFormat::Jpeg)
+            .unwrap();
 
-        let cache_dir = temp.join("cache");
+        let cache_dir = temp.path().join("cache");
         create_dir_all(&cache_dir).unwrap();
 
         let gen = ThumbnailGenerator::with_default_config(cache_dir).unwrap();
-        let path1 = gen.get_or_create_thumbnail(image_path.to_str().unwrap()).unwrap();
-        let path2 = gen.get_or_create_thumbnail(image_path.to_str().unwrap()).unwrap();
+        let path1 = gen
+            .get_or_create_thumbnail(image_path.to_str().unwrap())
+            .unwrap();
+        let path2 = gen
+            .get_or_create_thumbnail(image_path.to_str().unwrap())
+            .unwrap();
         assert_eq!(path1, path2, "Same image should return same cache path");
-
-        let _ = remove_dir_all(&temp);
     }
 }


### PR DESCRIPTION
## 概要

テストコード内の `std::env::temp_dir()` + 手動 `create_dir_all` / `remove_dir_all` パターンを、RAIIベースの `TempTestDir::new_random()` に統一。固定名ディレクトリも `new_random()` に変更し、並行テスト時の衝突リスクを排除。

## 変更内容

- `thumbnail/generator.rs`: `temp_dir()` の手動管理を `TempTestDir::new_random()` に置換。`create_test_generator()` の返り値を `(ThumbnailGenerator, TempTestDir)` に変更し、ライフタイム管理を改善
- `thumbnail/folder.rs`: 2テストを `TempTestDir::new_random()` に移行、手動 `remove_dir_all` 削除
- `fs.rs`: 同パターンのため追加で統一（`TempTestDir::new_random()` に移行）
- `test_helper.rs`: `TempTestDir` ユーティリティを新規作成（`new`, `new_random`, `Drop` 実装）
- `lib.rs`: `pub mod test_helper;` を追加
- `Cargo.toml`: `uuid` を dev-dependency に追加
- 不要な import（`temp_dir`, `remove_dir_all` 等）を整理

## テスト

- [x] `cargo test`: PASS（28 tests + 1 doc-test）
- [x] `pnpm type-check`: PASS
- [x] `pnpm lint`: PASS（3 warnings - 既存の無関係なもの）
- [x] `pnpm test`: PASS（346件）

## レビュー指摘事項

### 🟡 Warning（1件）

- **`lib.rs` の `#[cfg(test)]` ガード漏れ**: `pub mod test_helper;` が `#[cfg(test)]` なしで宣言されている。内部モジュールに `#[cfg(test)]` が付いているため実害は少ないが、本番ビルドでも空モジュールがクレートの公開 API に含まれる。後続 Issue で `#[cfg(test)] pub mod test_helper;` に修正予定。

### 🟢 Suggestion（4件）

- `TempTestDir::path()` の戻り値を `&PathBuf` → `&Path` に変更推奨（Rust API ガイドライン C-DEREF）
- `path` フィールドを非公開にし `path()` メソッドのみ公開推奨
- `TempTestDir::new(name)` を制限し `new_random()` のみ公開推奨（固定名パターン再発防止）
- `create_test_generator_with_config` の `#[allow(dead_code)]` — 使用されていないなら削除推奨

## 備考

Issue #52 のチェックリスト項目3「`image_container.rs` の import 整理」は、当該ファイルが `feature/core` ブランチに存在しないため N/A。

## 関連 Issue

closes #52