### PR TITLE
fix(image-viewer): consolidate viewer types on ImageSource

### DIFF
--- a/src/features/image-viewer/components/ImageDisplay.tsx
+++ b/src/features/image-viewer/components/ImageDisplay.tsx
@@ -1,17 +1,6 @@
 'use client';
 
-import type { ImageSource } from '../types/ImageSource';
-import type { ViewerSettings } from '../types/viewerTypes';
-
-export interface ImageDisplayProps {
-  image: ImageSource;
-  settings: ViewerSettings;
-  onLoad?: () => void;
-  onError?: (error: Error) => void;
-  className?: string;
-  style?: React.CSSProperties;
-  transitionType?: 'fade' | 'none';
-}
+import type { ImageDisplayProps } from '../types/viewerTypes';
 
 export function ImageDisplay({
   image,

--- a/src/features/image-viewer/components/ImageViewer.tsx
+++ b/src/features/image-viewer/components/ImageViewer.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState, useTransition } from 'react';
-import type { ImageContainer } from '@/features/image-viewer/types/ImageContainer';
 import type {
-  ImageViewerCallbacks,
-  KeyboardMapping,
+  ImageViewerProps,
   ViewerSettings,
 } from '@/features/image-viewer/types/viewerTypes';
 import { useImages } from '@/shared/hooks/data/useImages';
@@ -12,18 +10,6 @@ import { useControlsVisibility } from '../hooks/useControlsVisibility';
 import { useKeyboardHandler } from '../hooks/useKeyboardHandler';
 import { ImageDisplay } from './ImageDisplay';
 import { ViewerControls } from './ViewerControls';
-
-/**
- * ImageViewerProps: 画像コンテナまたはフォルダパスを受け取り、その中の画像を表示するビューアのprops
- */
-export interface ImageViewerProps {
-  container?: ImageContainer;
-  initialIndex?: number;
-  settings?: Partial<ViewerSettings>;
-  keyboardMapping?: KeyboardMapping;
-  callbacks?: ImageViewerCallbacks;
-  className?: string;
-}
 
 const defaultSettings: ViewerSettings = {
   fitMode: 'both',

--- a/src/features/image-viewer/components/ImageViewer.tsx
+++ b/src/features/image-viewer/components/ImageViewer.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useRef, useState, useTransition } from 'react';
 import type { ImageContainer } from '@/features/image-viewer/types/ImageContainer';
-import type { ImageSource } from '@/features/image-viewer/types/ImageSource';
 import type {
+  ImageViewerCallbacks,
   KeyboardMapping,
   ViewerSettings,
 } from '@/features/image-viewer/types/viewerTypes';
@@ -21,15 +21,7 @@ export interface ImageViewerProps {
   initialIndex?: number;
   settings?: Partial<ViewerSettings>;
   keyboardMapping?: KeyboardMapping;
-  callbacks?: {
-    onImageChange?: (index: number, image: ImageSource) => void;
-    onZoomChange?: (zoom: number) => void;
-    onRotationChange?: (rotation: number) => void;
-    onSettingsChange?: (settings: Partial<ViewerSettings>) => void;
-    onCustomAction?: (action: string, event: KeyboardEvent) => void;
-    onImageLoad?: (image: ImageSource) => void;
-    onImageError?: (error: Error, image: ImageSource) => void;
-  };
+  callbacks?: ImageViewerCallbacks;
   className?: string;
 }
 

--- a/src/features/image-viewer/index.ts
+++ b/src/features/image-viewer/index.ts
@@ -1,6 +1,5 @@
 // Image Viewer Feature Exports
 
-export type { ImageFile } from '../folder-navigation/types/folderTypes';
 export { ImageDisplay } from './components/ImageDisplay';
 // Re-export component props interfaces for convenience
 export type { ImageViewerProps } from './components/ImageViewer';

--- a/src/features/image-viewer/index.ts
+++ b/src/features/image-viewer/index.ts
@@ -1,9 +1,6 @@
 // Image Viewer Feature Exports
 
 export { ImageDisplay } from './components/ImageDisplay';
-// Re-export component props interfaces for convenience
-export type { ImageViewerProps } from './components/ImageViewer';
-// Components
 export { ImageViewer } from './components/ImageViewer';
 export { ViewerControls } from './components/ViewerControls';
 // Hooks
@@ -16,6 +13,7 @@ export type {
   ActionType,
   ImageDisplayProps,
   ImageViewerCallbacks,
+  ImageViewerProps,
   KeyboardMapping,
   KeyboardShortcut,
   ViewerControlsProps,

--- a/src/features/image-viewer/types/viewerTypes.ts
+++ b/src/features/image-viewer/types/viewerTypes.ts
@@ -1,3 +1,4 @@
+import type { ImageContainer } from './ImageContainer';
 import type { ImageSource } from './ImageSource';
 
 /**
@@ -13,6 +14,19 @@ export interface ViewerSettings {
   showControls: boolean;
   autoHideControls: boolean;
   controlsTimeout: number;
+}
+
+/**
+ * 画像ビューア本体のprops型。
+ * - ImageContainer 経由で画像一覧を受け取り表示する。
+ */
+export interface ImageViewerProps {
+  container?: ImageContainer;
+  initialIndex?: number;
+  settings?: Partial<ViewerSettings>;
+  keyboardMapping?: KeyboardMapping;
+  callbacks?: ImageViewerCallbacks;
+  className?: string;
 }
 
 /**
@@ -84,7 +98,6 @@ export interface KeyboardShortcut {
  * キーボードショートカットのマッピングを表す型。
  * - アクションごとにKeyboardShortcut配列を持つ。
  * - onActionでアクション発火時の処理を定義。
-
  */
 export interface KeyboardMapping {
   shortcuts: Map<ActionType, KeyboardShortcut[]>;

--- a/src/features/image-viewer/types/viewerTypes.ts
+++ b/src/features/image-viewer/types/viewerTypes.ts
@@ -1,10 +1,9 @@
-import type { ImageFile } from '../../folder-navigation/types/folderTypes';
+import type { ImageSource } from './ImageSource';
 
 /**
  * 画像ビューアの表示設定を表す型。
  * - ズーム、回転、背景色、コントロール表示などの設定を保持する。
  * - ImageViewerPropsやImageDisplayPropsで利用される。
-
  */
 export interface ViewerSettings {
   fitMode: 'width' | 'height' | 'both' | 'none';
@@ -18,15 +17,16 @@ export interface ViewerSettings {
 
 /**
  * 画像表示コンポーネントのprops型。
- * - ImageFile型のimageとViewerSettings型のsettingsを受け取る。
+ * - ImageSource型のimageとViewerSettings型のsettingsを受け取る。
  */
 export interface ImageDisplayProps {
-  image: ImageFile;
+  image: ImageSource;
   settings: ViewerSettings;
   onLoad?: () => void;
   onError?: (error: Error) => void;
   className?: string;
   style?: React.CSSProperties;
+  transitionType?: 'fade' | 'none';
 }
 
 /**
@@ -95,14 +95,14 @@ export interface KeyboardMapping {
 /**
  * 画像ビューアのコールバック関数群。
  * - ImageViewerPropsで利用される。
- * - ImageFile型やViewerSettings型と連携する。
+ * - ImageSource型やViewerSettings型と連携する。
  */
 export interface ImageViewerCallbacks {
-  onImageChange?: (index: number, image: ImageFile) => void;
+  onImageChange?: (index: number, image: ImageSource) => void;
   onZoomChange?: (zoom: number) => void;
   onRotationChange?: (rotation: number) => void;
   onSettingsChange?: (settings: Partial<ViewerSettings>) => void;
   onCustomAction?: (action: string, event: KeyboardEvent) => void;
-  onImageLoad?: (image: ImageFile) => void;
-  onImageError?: (error: Error, image: ImageFile) => void;
+  onImageLoad?: (image: ImageSource) => void;
+  onImageError?: (error: Error, image: ImageSource) => void;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes type drift in the image-viewer feature where `viewerTypes.ts` still referenced `ImageFile` while components actually use `ImageSource`.

## Changes

- Update `viewerTypes.ts` to use `ImageSource` for `ImageDisplayProps` and `ImageViewerCallbacks`
- Add `transitionType` to the canonical `ImageDisplayProps` definition
- Remove duplicate `ImageDisplayProps` from `ImageDisplay.tsx`
- Use `ImageViewerCallbacks` type in `ImageViewer` props instead of inline callbacks
- Remove cross-feature `ImageFile` re-export from `image-viewer/index.ts`

## Why

Barrel imports from `image-viewer` were exporting stale types that did not match component implementations, increasing cognitive load and risk of incorrect usage.

## Testing

- `npm run type-check` passes
- All 317 tests pass (including image-viewer tests)

---

## Follow-up (cognitive load)

- Move `ImageViewerProps` into `viewerTypes.ts` alongside Display/Controls props
- Export `ImageViewerProps` from the types barrel, not the component file
- Keep a single place to read viewer public prop shapes

Merge note: touches `src/features/image-viewer/index.ts` — check conflict with #93 (both remove the `ImageFile` re-export).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4217ad6-e407-47c1-b5cc-18d0ac17bd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4217ad6-e407-47c1-b5cc-18d0ac17bd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

